### PR TITLE
Customise bug report template to be more specific.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -13,8 +13,8 @@ A clear and concise description of what the bug is.
 **To Reproduce**
 Steps to reproduce the behavior:
 1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
+2. Click on '...'
+3. Press key '...'
 4. See error
 
 **Expected behavior**
@@ -23,16 +23,11 @@ A clear and concise description of what you expected to happen.
 **Screenshots**
 If applicable, add screenshots to help explain your problem.
 
-**Desktop (please complete the following information):**
- - OS: [e.g. iOS]
- - Browser [e.g. chrome, safari]
- - Version [e.g. 22]
-
-**Smartphone (please complete the following information):**
- - Device: [e.g. iPhone6]
- - OS: [e.g. iOS8.1]
- - Browser [e.g. stock browser, safari]
- - Version [e.g. 22]
+**Environment/System (please complete the following information):**
+ - OS: [e.g. Windows/Linux/MacOS]
+ - Application version: [e.g. v1.3.5]
+ - Commit: [if building from source]
+ - Compiler: [if building from source - MSVC/GCC/Clang]
 
 **Additional context**
 Add any other context about the problem here.


### PR DESCRIPTION
The previous bug report template looked rather generic & contained some information that we don't care about or doesn't apply to us - for example browser versions or smartphones etc...
This makes the bug report template slightly more specific to our needs.