### PR TITLE
Make Engine linked libraries PRIVATE in scope to fix Windows build

### DIFF
--- a/Engine/CMakeLists.txt
+++ b/Engine/CMakeLists.txt
@@ -52,7 +52,7 @@ target_include_directories(${PROJECT_NAME} PUBLIC
 	${CMAKE_CURRENT_LIST_DIR}/ThirdParty/ImGui/examples
 )
 
-target_link_libraries(${PROJECT_NAME} SDL2-static SDL2main Glad ImGui)
+target_link_libraries(${PROJECT_NAME} PRIVATE SDL2-static SDL2main Glad ImGui)
 
 if(WIN32)
 	target_link_libraries(${PROJECT_NAME} PRIVATE opengl32.lib)


### PR DESCRIPTION
I did a fresh clone & CMake was complaining about not all `target_link_libraries` calls where consistent in the use of the `PUBLIC/PRIVATE/INTERFACE` keywords. This fixes that & makes some libraries PRIVATE in scope.