### PR TITLE
fix (ImGUI): Added preprocessor directive to ensure glad usage.

### DIFF
--- a/Engine/CMakeLists.txt
+++ b/Engine/CMakeLists.txt
@@ -1,5 +1,15 @@
 project(Engine)
 
+# FIX: @ThirdParty @ImGUI
+#   Properly specify which interface (ie. glad) to use with ImGui_ImplOpenGL3.h
+#   otherwise it guesses which interface to use and may throw a linker error.
+#
+# NOTE:
+#   Should replace -> https://cmake.org/cmake/help/latest/command/add_definitions.html
+#   with this -> https://cmake.org/cmake/help/latest/command/add_compile_definitions.html#command:add_compile_definitions
+#   if we migrate / update to the latest version of cmake.
+add_definitions(-DIMGUI_IMPL_OPENGL_LOADER_GLAD)
+
 add_subdirectory(ThirdParty)
 
 set (Headers ${CMAKE_CURRENT_LIST_DIR}/Include/Quartz2)


### PR DESCRIPTION
Prior to this commit I assume ImGUI was trying to guess which
library to link against when implementing the OpenGL3 interface,
and as a result was trying to grab libglew from my computer in
place of the locally managed glad suite. This fixes that issue.

I also assume the third party libraries are all managed through
git submodules instead of static copies within our repo, as such
I had to apply the preprocessor directive to every third party
library. It shouldn't create any conflicts, but figured I'd
give y'all a heads up just in case.