### PR TITLE
Remove "sudo" attribute from Travis CI config.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: cpp
 dist: bionic
 osx_image: xcode11.3
-sudo: required
 os:
     - linux
     - osx


### PR DESCRIPTION
The sudo attribute is deprecated, it doesn't do anything anymore.