### PR TITLE
Block + Texture Registry

### DIFF
--- a/Engine/Include/Quartz2/CMakeLists.txt
+++ b/Engine/Include/Quartz2/CMakeLists.txt
@@ -1,12 +1,14 @@
 add_subdirectory(Math)
 add_subdirectory(Events)
 add_subdirectory(Graphics)
+add_subdirectory(Voxels)
 
 set(currentDir ${CMAKE_CURRENT_LIST_DIR})
 set(Headers
 	${mathHeaders}
 	${eventHeaders}
 	${graphicsHeaders}
+	${voxelHeaders}
 
 	${currentDir}/EnumTools.hpp
 

--- a/Engine/Include/Quartz2/Voxels/Block.hpp
+++ b/Engine/Include/Quartz2/Voxels/Block.hpp
@@ -1,0 +1,83 @@
+// Copyright 2019 Genten Studios
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#include <Quartz2/Math/Math.hpp>
+
+#include <array>
+#include <string>
+
+namespace q2
+{
+	namespace voxels
+	{
+		enum class BlockCategory : unsigned int
+		{
+			AIR,
+			SOLID,
+			LIQUID
+		};
+
+		class BlockType
+		{
+		public:
+			BlockType()  = default;
+			~BlockType() = default;
+
+			std::string displayName;
+			std::string id;
+
+			BlockCategory category = BlockCategory::AIR;
+
+			// top, left, back, right, top, bottom
+			std::array<std::string, 6> textures;
+
+			void setAllTextures(const std::string& tex) { textures.fill(tex); }
+
+			std::size_t getRegistryID() const { return m_registryID; }
+
+			bool operator==(const BlockType& rhs) const
+			{
+				return (id == rhs.id);
+			}
+
+		private:
+			std::size_t m_registryID = -1;
+			friend class BlockRegistry;
+		};
+
+		struct BlockMetadata
+		{
+			math::vec3  blockPos;
+			std::string data; // serialised data, we can decide how we wanna do
+			                  // this some other time (just an implementation
+			                  // attempt to stop pains later in life.)
+		};
+	} // namespace voxels
+} // namespace q2

--- a/Engine/Include/Quartz2/Voxels/BlockRegistry.hpp
+++ b/Engine/Include/Quartz2/Voxels/BlockRegistry.hpp
@@ -1,0 +1,67 @@
+// Copyright 2019 Genten Studios
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#include <Quartz2/Singleton.hpp>
+#include <Quartz2/Voxels/Block.hpp>
+#include <Quartz2/Voxels/TextureRegistry.hpp>
+
+#include <vector>
+
+namespace q2
+{
+	namespace voxels
+	{
+		class BlockRegistry : public Singleton<BlockRegistry>
+		{
+		public:
+			void initialise();
+
+			void       registerBlock(BlockType blockInfo);
+			BlockType* getFromID(const std::string& id);
+
+			// registry int is stored in the block, it's a quicker way of
+			// getting a block's data. do NOT store this in chunk data, that is
+			// only valid once the registry table is built.
+			BlockType* getFromRegistryID(std::size_t registryID);
+
+			TextureRegistry* getTextures();
+
+		private:
+			// NOTE: We used to use an std::list to prevent invalidating any
+			// pointers, however, since all blocks will be registered in ONE go
+			// from a Lua initialisation, these pointers will not be invalidated
+			// for their whole lifetime, until the block registry is destroyed -
+			// but that will be quite late in the destruction of the program so
+			// this *shouldn't* be an issue. - @beeperdeeper089
+			std::vector<BlockType> m_blocks;
+			TextureRegistry        m_textures;
+		};
+	} // namespace voxels
+} // namespace q2

--- a/Engine/Include/Quartz2/Voxels/CMakeLists.txt
+++ b/Engine/Include/Quartz2/Voxels/CMakeLists.txt
@@ -1,0 +1,8 @@
+set(currentDir ${CMAKE_CURRENT_LIST_DIR})
+set(voxelHeaders
+	${currentDir}/Block.hpp
+	${currentDir}/BlockRegistry.hpp
+	${currentDir}/TextureRegistry.hpp
+
+	PARENT_SCOPE
+)

--- a/Engine/Include/Quartz2/Voxels/TextureRegistry.hpp
+++ b/Engine/Include/Quartz2/Voxels/TextureRegistry.hpp
@@ -1,0 +1,63 @@
+// Copyright 2019 Genten Studios
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+namespace q2
+{
+	namespace voxels
+	{
+		class TextureRegistry
+		{
+		public:
+			void                     addTexture(const std::string& texture);
+			std::vector<std::string> getTextures();
+
+		private:
+			// NOTE: We could have used an std::vector in this case (as done in
+			// the BlockRegistry)
+			//
+			// if (std::find(m_textures.begin(), m_textures.end(), texture) ==
+			// m_textures.end())
+			// {
+			//   m_textures.push_back(texture);
+			// }
+			//
+			// Here we are performing a search every time we insert an element,
+			// so each one by itself is upto O(N) complexity, resulting in an
+			// O(N*N) complexity overall. However, std::unordered_set has a
+			// constant time look-up, giving the overall ~O(N) complexity.
+			// - @beeperdeeper089
+			std::unordered_set<std::string> m_textures;
+		};
+	} // namespace voxels
+} // namespace q2

--- a/Engine/Source/CMakeLists.txt
+++ b/Engine/Source/CMakeLists.txt
@@ -1,10 +1,12 @@
 add_subdirectory(Math)
 add_subdirectory(Graphics)
+add_subdirectory(Voxels)
 
 set(currentDir ${CMAKE_CURRENT_LIST_DIR})
 set(Sources
 	${mathSources}
 	${graphicsSources}
+	${voxelSources}
 
 	${currentDir}/ChunkRenderer.cpp
 	${currentDir}/ShaderCompiler.cpp

--- a/Engine/Source/Voxels/BlockRegistry.cpp
+++ b/Engine/Source/Voxels/BlockRegistry.cpp
@@ -1,0 +1,91 @@
+// Copyright 2019 Genten Studios
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include <Quartz2/Voxels/BlockRegistry.hpp>
+
+#include <algorithm>
+#include <cstring>
+
+using namespace q2::voxels;
+
+void BlockRegistry::initialise()
+{
+	BlockType unknownBlock;
+	unknownBlock.displayName = "Unknown Block";
+	unknownBlock.id          = "core:unknown";
+	unknownBlock.category    = BlockCategory::SOLID;
+	unknownBlock.setAllTextures("Assets/unknown.png");
+	registerBlock(unknownBlock);
+
+	BlockType outOfBoundsBlock;
+	outOfBoundsBlock.displayName = "Out Of Bounds";
+	outOfBoundsBlock.id          = "core:out_of_bounds";
+	outOfBoundsBlock.category    = BlockCategory::AIR;
+	registerBlock(outOfBoundsBlock);
+}
+
+void BlockRegistry::registerBlock(BlockType blockInfo)
+{
+	if (std::find(m_blocks.begin(), m_blocks.end(), blockInfo) ==
+	    m_blocks.end())
+	{
+		blockInfo.m_registryID = m_blocks.size();
+		m_blocks.push_back(blockInfo);
+
+		if (blockInfo.category != BlockCategory::AIR)
+		{
+			for (const std::string& tex : blockInfo.textures)
+			{
+				m_textures.addTexture(tex);
+			}
+		}
+	}
+}
+
+BlockType* BlockRegistry::getFromID(const std::string& id)
+{
+	auto it = std::find_if(
+	    m_blocks.begin(), m_blocks.end(), [id](const BlockType& block) {
+		    return std::strcmp(block.id.c_str(), id.c_str()) == 0;
+	    });
+
+	return it == m_blocks.end() ? getFromRegistryID(0)
+	                            : &(*it); // 0 is always unknown.
+}
+
+BlockType* BlockRegistry::getFromRegistryID(std::size_t registryID)
+{
+	if (registryID > m_blocks.size())
+	{
+		return &m_blocks[0];
+	}
+
+	return &m_blocks[registryID];
+}
+
+TextureRegistry* BlockRegistry::getTextures() { return &m_textures; }

--- a/Engine/Source/Voxels/CMakeLists.txt
+++ b/Engine/Source/Voxels/CMakeLists.txt
@@ -1,0 +1,7 @@
+set(currentDir ${CMAKE_CURRENT_LIST_DIR})
+set(voxelSources
+	${currentDir}/BlockRegistry.cpp
+	${currentDir}/TextureRegistry.cpp
+
+	PARENT_SCOPE
+)

--- a/Engine/Source/Voxels/TextureRegistry.cpp
+++ b/Engine/Source/Voxels/TextureRegistry.cpp
@@ -1,0 +1,41 @@
+// Copyright 2019 Genten Studios
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include <Quartz2/Voxels/TextureRegistry.hpp>
+
+using namespace q2::voxels;
+
+void TextureRegistry::addTexture(const std::string& texture)
+{
+	m_textures.insert(texture);
+}
+
+std::vector<std::string> TextureRegistry::getTextures()
+{
+	return {m_textures.begin(), m_textures.end()};
+}


### PR DESCRIPTION
Addresses: None
Authors:
@beeperdeeper089  

## Summary of changes
  - Newer block registry system
  - Texture handling system, no more duplicates. simpler system
  
## Caveats
  - There is a soft limit of 256 textures, more than this is UB since each graphics card supports a different amount of layers within a texture array.

## On approval
Please merge