### PR TITLE
Give mouse control when clicking off of the window.

### DIFF
--- a/Phoenix/Client/Source/Client.cpp
+++ b/Phoenix/Client/Source/Client.cpp
@@ -142,4 +142,3 @@ void Client::run()
 
 	Settings::get()->save();
 }
-

--- a/Phoenix/Client/Source/Game.cpp
+++ b/Phoenix/Client/Source/Game.cpp
@@ -187,7 +187,13 @@ void Game::onEvent(events::Event& e)
 		default:
 			break;
 		}
-
+		break;
+	case events::EventType::WINDOW_DEFOCUSED:
+		m_camera->enable(false);
+		break;
+	case events::EventType::WINDOW_FOCUSED:
+		m_camera->enable(true);
+		break;
 	default:
 		break;
 	}


### PR DESCRIPTION
Resolves: #157 
Authors:
@beeperdeeper089 

## Summary of changes
-  Give back control of mouse if you defocus the window (like alt-tab out).
-  Take back control of the mouse if you focus the window (like alt-tab in).
  
## Caveats
Does this introduce any new bugs?
-  None

## On approval
Please merge.