### PR TITLE
using json for the settings - draft

### DIFF
--- a/Phoenix/Common/Include/Common/Settings.hpp
+++ b/Phoenix/Common/Include/Common/Settings.hpp
@@ -40,6 +40,9 @@
 
 #include <string>
 #include <unordered_map>
+#include <nlohmann/json.hpp>
+
+using json = nlohmann::json;
 
 namespace phx
 {
@@ -71,6 +74,9 @@ namespace phx
 		/// @brief Minimum value that the setting can be set to.
 		int m_minValue;
 
+		/// @brief A pointer to the JSON object to be able to update it
+		json* m_json;
+
 	public:
 		Setting() = default;
 
@@ -81,7 +87,7 @@ namespace phx
 		 * @param key The unique name for the setting in the format core:volume.
 		 * @param defaultValue The default value for the setting upon creation.
 		 */
-		Setting(std::string name, std::string key, int defaultValue);
+		Setting(std::string name, std::string key, int defaultValue, json* json_);
 
 		/**
 		 * @brief Sets the value of an already existing setting.
@@ -181,6 +187,6 @@ namespace phx
 
 	private:
 		std::unordered_map<std::string, Setting> m_settings;
-		std::unordered_map<std::string, int>     m_unused;
+		json m_data;
 	};
 }; // namespace phx


### PR DESCRIPTION
Resolves: #166 
Authors:
@SuperFola 

## Summary of changes
-  using nlohmann::json to load/save the settings
- the Setting now have to update data in the json object (they have a pointer to it) every time we do a Setting.set(value)
  
## Caveats
Does this introduce any new bugs?
- I hope not

## On approval
Wait for me before merging