### PR TITLE
Feat enet queue

### DIFF
--- a/Phoenix/Server/Include/Server/CMakeLists.txt
+++ b/Phoenix/Server/Include/Server/CMakeLists.txt
@@ -2,6 +2,7 @@ set(currentDir ${CMAKE_CURRENT_LIST_DIR})
 set(Headers
 		${currentDir}/Server.hpp
 		${currentDir}/Iris.hpp
+		${currentDir}/Game.hpp
 		${currentDir}/Commander.hpp
 
 		PARENT_SCOPE

--- a/Phoenix/Server/Include/Server/Game.hpp
+++ b/Phoenix/Server/Include/Server/Game.hpp
@@ -37,7 +37,7 @@ namespace phx::server
 	class Game
 	{
 	public:
-		Game(entt::registry* registry, bool* running, networking::Iris iris);
+		Game(entt::registry* registry, bool* running, networking::Iris* iris);
 
 		void run();
 

--- a/Phoenix/Server/Include/Server/Game.hpp
+++ b/Phoenix/Server/Include/Server/Game.hpp
@@ -41,6 +41,8 @@ namespace phx::server
 
 		void run();
 
+		static constexpr float dt = 1.f / 20.f;
+
 	private:
 		bool* m_running;
 

--- a/Phoenix/Server/Include/Server/Game.hpp
+++ b/Phoenix/Server/Include/Server/Game.hpp
@@ -28,38 +28,24 @@
 
 #pragma once
 
-#include <Server/Game.hpp>
 #include <Server/Iris.hpp>
 
-#include <Server/User.hpp>
-
-//#include <Server/Commander.hpp>
-
 #include <entt/entt.hpp>
-#include <enet/enet.h>
-
-#include <array>
-#include <string>
 
 namespace phx::server
 {
-
-	class Server
+	class Game
 	{
 	public:
-		Server(std::string save);
-		~Server();
+		Game(entt::registry* registry, bool* running, networking::Iris iris);
 
 		void run();
 
 	private:
-		bool m_running;
+		bool* m_running;
 
-		entt::registry m_registry;
+		entt::registry* m_registry;
 
 		networking::Iris* m_iris;
-		Game*             m_game;
-
-		std::string m_save;
 	};
 } // namespace phx::server

--- a/Phoenix/Server/Include/Server/Iris.hpp
+++ b/Phoenix/Server/Include/Server/Iris.hpp
@@ -33,11 +33,32 @@
 #	define NOMINMAX
 #endif
 
+#include <Common/Input.hpp>
+
 #include <enet/enet.h>
 #include <entt/entt.hpp>
 
 namespace phx::server::networking
 {
+	struct StateBundle
+	{
+		bool                                          ready;
+		std::size_t                                   users;
+		std::size_t                                   sequence;
+		std::unordered_map<entt::entity*, InputState> states;
+	};
+
+	struct EventBundle
+	{
+		entt::entity* userRef;
+	};
+
+	struct MessageBundle
+	{
+		entt::entity* userRef;
+		std::string   message;
+	};
+
 	class Iris
 	{
 	public:
@@ -56,6 +77,10 @@ namespace phx::server::networking
 		void sendEvent(entt::entity* userRef, enet_uint8* data);
 		void sendState(std::size_t sequence);
 		void sendMessage(entt::entity* userRef, enet_uint8* data);
+
+		std::list<StateBundle>   stateQueue;
+		std::list<EventBundle>   eventQueue;
+		std::list<MessageBundle> messageQueue;
 
 	private:
 		bool* m_running;

--- a/Phoenix/Server/Source/CMakeLists.txt
+++ b/Phoenix/Server/Source/CMakeLists.txt
@@ -1,10 +1,11 @@
 set(currentDir ${CMAKE_CURRENT_LIST_DIR})
 set(Sources
-		${currentDir}/Server.cpp
-		${currentDir}/Iris.cpp
-		${currentDir}/Commander.cpp
+        ${currentDir}/Server.cpp
+        ${currentDir}/Iris.cpp
+        ${currentDir}/Game.cpp
+        ${currentDir}/Commander.cpp
 
-		${currentDir}/Main.cpp
+        ${currentDir}/Main.cpp
 
-		PARENT_SCOPE
-		)
+        PARENT_SCOPE
+        )

--- a/Phoenix/Server/Source/Game.cpp
+++ b/Phoenix/Server/Source/Game.cpp
@@ -62,6 +62,8 @@ void Game::run()
 				ActorSystem::tick(m_registry,
 				                  m_registry->get<Player>(*state.first).actor,
 				                  dt, state.second);
+
+				// @todo remove this debug statement before merging to develop
 				std::cout
 				    << m_registry
 				           ->get<Position>(

--- a/Phoenix/Server/Source/Game.cpp
+++ b/Phoenix/Server/Source/Game.cpp
@@ -26,40 +26,39 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-#pragma once
-
 #include <Server/Game.hpp>
-#include <Server/Iris.hpp>
-
 #include <Server/User.hpp>
 
-//#include <Server/Commander.hpp>
+#include <Common/Actor.hpp>
+#include <Common/Movement.hpp>
+#include <Common/Position.hpp>
 
-#include <entt/entt.hpp>
-#include <enet/enet.h>
+using namespace phx;
+using namespace phx::server;
 
-#include <array>
-#include <string>
-
-namespace phx::server
+Game::Game(entt::registry* registry, bool* running, networking::Iris* iris)
+    : m_registry(registry), m_running(running), m_iris(iris)
 {
+}
 
-	class Server
+void Game::run()
+{
+	while (m_running)
 	{
-	public:
-		Server(std::string save);
-		~Server();
+		// @todo @beeper is this efficient? we process a state 20 times a second
+		while (m_iris->stateQueue.front().ready == false)
+		{ /* Waiting */
+		}
 
-		void run();
+		InputState m_currentState = m_iris->stateQueue.front();
+		m_iris->stateQueue.pop_front();
 
-	private:
-		bool m_running;
-
-		entt::registry m_registry;
-
-		networking::Iris* m_iris;
-		Game*             m_game;
-
-		std::string m_save;
-	};
-} // namespace phx::server
+		ActorSystem::tick(m_registry, m_registry->get<Player>(*userRef).actor,
+		                  dt, input);
+		std::cout << m_registry
+		                 ->get<Position>(
+		                     m_registry->get<Player>(*userRef).actor)
+		                 .position
+		          << "\n";
+	}
+}

--- a/Phoenix/Server/Source/Game.cpp
+++ b/Phoenix/Server/Source/Game.cpp
@@ -43,6 +43,8 @@ Game::Game(entt::registry* registry, bool* running, networking::Iris* iris)
 
 void Game::run()
 {
+	static const float dt = 1.f / 20.f;
+
 	while (m_running)
 	{
 		// @todo @beeper is this efficient? we process a state 20 times a second
@@ -50,15 +52,19 @@ void Game::run()
 		{ /* Waiting */
 		}
 
-		InputState m_currentState = m_iris->stateQueue.front();
+		networking::StateBundle m_currentState = m_iris->stateQueue.front();
 		m_iris->stateQueue.pop_front();
 
-		ActorSystem::tick(m_registry, m_registry->get<Player>(*userRef).actor,
-		                  dt, input);
-		std::cout << m_registry
-		                 ->get<Position>(
-		                     m_registry->get<Player>(*userRef).actor)
-		                 .position
-		          << "\n";
+		for (auto state : m_currentState.states)
+		{
+			ActorSystem::tick(m_registry,
+			                  m_registry->get<Player>(*state.first).actor, dt,
+			                  state.second);
+			std::cout << m_registry
+			                 ->get<Position>(
+			                     m_registry->get<Player>(*state.first).actor)
+			                 .position
+			          << "\n";
+		}
 	}
 }

--- a/Phoenix/Server/Source/Game.cpp
+++ b/Phoenix/Server/Source/Game.cpp
@@ -66,5 +66,6 @@ void Game::run()
 			                 .position
 			          << "\n";
 		}
+		m_iris::sendState(stateQueue.sequence);
 	}
 }

--- a/Phoenix/Server/Source/Iris.cpp
+++ b/Phoenix/Server/Source/Iris.cpp
@@ -201,10 +201,6 @@ void Iris::parseState(entt::entity* userRef, enet_uint8* data)
 	{
 		stateQueue.front().ready = true;
 	}
-
-	// @todo this needs triggered by the game loop after all states have been
-	// received.
-	sendState(input.sequence);
 }
 void Iris::parseMessage(entt::entity* userRef, enet_uint8* data)
 {

--- a/Phoenix/Server/Source/Iris.cpp
+++ b/Phoenix/Server/Source/Iris.cpp
@@ -159,29 +159,36 @@ void Iris::parseState(entt::entity* userRef, enet_uint8* data)
 
 	/// @todo This is going to error out when the size_t loops, we can get
 	/// around this with some logic checking for that.
-	if (input.sequence < stateQueue.front().sequence)
+	if (input.sequence > stateQueue.end()->sequence || stateQueue.empty())
 	{
-		// Discard if we have already processed this sequence
-	}
-	else if (input.sequence > stateQueue.end()->sequence)
-	{
+		printf("insert new");
 		// Insert a new bundle if this is the first packet in this sequence
 		StateBundle bundle;
 		bundle.sequence        = input.sequence;
 		bundle.ready           = false;
 		bundle.states[userRef] = input;
 		bundle.users = 1; ///@todo We need to capture how many users we are
-		                  ///expecting packets from
+		/// expecting packets from
+		if (bundle.states.size() >= bundle.users)
+		{
+			bundle.ready = true;
+		}
 		stateQueue.push_back(bundle);
+	}
+	else if (input.sequence < stateQueue.front().sequence)
+	{
+		printf("discard");
+		// Discard if we have already processed this sequence
 	}
 	else
 	{
+		printf("insert existing");
 		for (auto bundle : stateQueue)
 		{
 			if (bundle.sequence == input.sequence)
 			{
 				// Thread safety! If we said a bundle is ready, were too late
-				if (bundle.ready != true)
+				if (!bundle.ready)
 				{
 					bundle.states[userRef] = input;
 					// If we have all the states we need, then the bundle is

--- a/Phoenix/Server/Source/Iris.cpp
+++ b/Phoenix/Server/Source/Iris.cpp
@@ -69,7 +69,7 @@ Iris::~Iris() { enet_host_destroy(m_server); }
 
 void Iris::run()
 {
-	while (enet_host_service(m_server, &m_event, 1000 / 20) > 0 && m_running)
+	while (enet_host_service(m_server, &m_event, 50) > 0 && m_running)
 	{
 		switch (m_event.type)
 		{
@@ -115,7 +115,7 @@ void Iris::run()
 
 		case ENET_EVENT_TYPE_DISCONNECT:
 			printf("%s disconnected.\n",
-			       reinterpret_cast<const char*>(m_event.peer->data));
+			       static_cast<const char*>(m_event.peer->data));
 			break;
 
 		case ENET_EVENT_TYPE_NONE:

--- a/Phoenix/Server/Source/Iris.cpp
+++ b/Phoenix/Server/Source/Iris.cpp
@@ -171,17 +171,17 @@ void Iris::parseState(entt::entity* userRef, enet_uint8* data)
 	}
 
 	// Discard state if its older that the oldest stateBundle
-	if (input.sequence < stateQueue.front().sequence)
+	if (input.sequence < stateQueue.front().sequence &&
+	    stateQueue.end()->sequence - input.sequence < 10)
 	{
 		printf("discard %lu \n", input.sequence);
 		return;
 	}
 
-	/// @todo This is going to error out when the size_t loops, we can get
-	/// around this with some logic checking for that.
-
 	// Fill the stateBundles up to the current input sequence
-	while (input.sequence > stateQueue.end()->sequence)
+	while ((input.sequence > stateQueue.end()->sequence &&
+	        input.sequence - stateQueue.end()->sequence > 10) ||
+	       stateQueue.end()->sequence == 255)
 	{
 		// Insert a new bundle if this is the first packet in this sequence
 		StateBundle bundle;

--- a/Phoenix/Server/Source/Iris.cpp
+++ b/Phoenix/Server/Source/Iris.cpp
@@ -71,7 +71,7 @@ void Iris::run()
 {
 	while (m_running)
 	{
-		while (enet_host_service(m_server, &m_event, 1000 / 20) > 0)
+		while (enet_host_service(m_server, &m_event, 0) > 0)
 		{
 			switch (m_event.type)
 			{

--- a/Phoenix/Server/Source/Iris.cpp
+++ b/Phoenix/Server/Source/Iris.cpp
@@ -159,7 +159,7 @@ void Iris::parseState(entt::entity* userRef, enet_uint8* data)
 
 	/// @todo This is going to error out when the size_t loops, we can get
 	/// around this with some logic checking for that.
-	if (input.sequence < stateQueue.front()->sequence)
+	if (input.sequence < stateQueue.front().sequence)
 	{
 		// Discard if we have already processed this sequence
 	}

--- a/Phoenix/Server/Source/Iris.cpp
+++ b/Phoenix/Server/Source/Iris.cpp
@@ -158,8 +158,6 @@ void Iris::parseState(entt::entity* userRef, enet_uint8* data)
 	input.down     = data[1] & static_cast<char>(1 << 2);
 
 	// If the queue is empty we need to add a new bundle
-	// @todo this is probably going to skip states if the server is grabbing
-	// states instantly, we should work around that.
 	if (stateQueue.empty())
 	{
 		StateBundle bundle;

--- a/Phoenix/Server/Source/Server.cpp
+++ b/Phoenix/Server/Source/Server.cpp
@@ -50,6 +50,7 @@ void Server::run()
 	m_running = true;
 
 	std::thread t_iris(&networking::Iris::run, m_iris);
+	std::thread t_game(&Game::run, m_game);
 
 	std::string input;
 	while (m_running)
@@ -61,7 +62,8 @@ void Server::run()
 			m_running = false;
 		}
 	}
-
+	t_iris.join();
+	t_game.join();
 	Settings::get()->save("config.txt");
 }
 

--- a/Phoenix/Server/Source/Server.cpp
+++ b/Phoenix/Server/Source/Server.cpp
@@ -26,8 +26,9 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-#include <Common/Settings.hpp>
 #include <Server/Server.hpp>
+
+#include <Common/Settings.hpp>
 
 #include <iostream>
 #include <thread>
@@ -39,6 +40,7 @@ using namespace phx;
 Server::Server(std::string save) : m_save(std::move(save))
 {
 	m_iris = new networking::Iris(&m_registry, &m_running);
+	m_game = new Game(&m_registry, &m_running, m_iris);
 }
 
 void Server::run()


### PR DESCRIPTION
Authors:
@apachano 

## Summary of changes
-  Adds a queuing system and builds that system for state processing
-  Processes queued states in their sequence order
  
## Caveats
Does this introduce any new bugs?
-  This only works with one user, we still need to capture how many users we are expecting packets from.