### PR TITLE
Implement logging into Lua

### DIFF
--- a/Phoenix/Client/Source/Game.cpp
+++ b/Phoenix/Client/Source/Game.cpp
@@ -98,6 +98,19 @@ Game::Game(gfx::Window* window, entt::registry* registry)
 	InputMap::get()->registerAPI(m_modManager);
 	CommandBook::get()->registerAPI(m_modManager);
 
+	m_modManager->registerFunction("core.log_warning", [](std::string message) {
+		LOG_WARNING("MODULE") << message;
+	});
+	m_modManager->registerFunction("core.log_fatal", [](std::string message) {
+		LOG_FATAL("MODULE") << message;
+	});
+	m_modManager->registerFunction("core.log_info", [](std::string message) {
+		LOG_INFO("MODULE") << message;
+	});
+	m_modManager->registerFunction("core.log_debug", [](std::string message) {
+		LOG_DEBUG("MODULE") << message;
+	});
+
 	m_modManager->registerFunction(
 	    "audio.loadMP3",
 	    [=](const std::string& uniqueName, const std::string& filePath) {

--- a/Phoenix/Modules/mod1/Init.lua
+++ b/Phoenix/Modules/mod1/Init.lua
@@ -1,4 +1,4 @@
-print ("Load mod 1")
+core.log_info("Load mod 1")
 
 function hello (args)
     if args[1] == "there" then

--- a/Phoenix/Modules/mod2/Init.lua
+++ b/Phoenix/Modules/mod2/Init.lua
@@ -1,2 +1,2 @@
-print ("Load mod 2")
+core.log_info("Load mod 2")
 --voxel.block.register("core.stone", "Stone")

--- a/Phoenix/Modules/mod3/Init.lua
+++ b/Phoenix/Modules/mod3/Init.lua
@@ -1,2 +1,2 @@
-print ("Load mod 3")
+core.log_info("Load mod 3")
 --voxel.block.register("core.cobble", "CobbleStone")


### PR DESCRIPTION
Authors:
@apachano 

## Summary of changes
- Implements Logging API in Lua
  
## Caveats
Does this introduce any new bugs?
- API can't be implemented in Logging.hpp else a circular dependency is formed and breaks compilation
- There is no way to reliably determine which mod calls the logging function so all modules log as the same component

## On approval
Merge
