### PR TITLE
Fix annoying warning with audio system.

### DIFF
--- a/Phoenix/Client/Include/Client/Client.hpp
+++ b/Phoenix/Client/Include/Client/Client.hpp
@@ -52,7 +52,7 @@ namespace phx::client
 		bool isDebugLayerActive() const { return m_debugOverlayActive; }
 
 		audio::Audio*      getAudioHandler() { return m_audio; }
-		audio::SourcePool* getAudioPool() { return &m_audioPool; }
+		audio::SourcePool* getAudioPool() { return m_audioPool; }
 
 		void onEvent(events::Event e) override;
 		void run();
@@ -61,7 +61,7 @@ namespace phx::client
 	    entt::registry  m_registry;
 
 		audio::Audio* m_audio;
-		audio::SourcePool m_audioPool;
+		audio::SourcePool* m_audioPool;
 		
 		gfx::Window     m_window;
 		gfx::LayerStack m_layerStack;

--- a/Phoenix/Client/Source/Client.cpp
+++ b/Phoenix/Client/Source/Client.cpp
@@ -125,6 +125,7 @@ void Client::run()
 
 	audio::Audio::initialize();
 	m_audio = new audio::Audio();
+	m_audioPool = new audio::SourcePool();
 
 	SplashScreen* splashScreen = new SplashScreen();
 	m_layerStack.pushLayer(splashScreen);
@@ -142,11 +143,14 @@ void Client::run()
 		if (!m_layerStack.empty())
 			m_layerStack.tick(dt);
 
-		m_audioPool.tick();
+		m_audioPool->tick();
 
 		m_window.endFrame();
 	}
 
+	delete m_audioPool;
+	delete m_audio;
+	
 	audio::Audio::teardown();
 
 	Settings::get()->save("settings.txt");


### PR DESCRIPTION
Resolves: #
Authors:
@beeperdeeper089 

## Summary of changes
- Make sure the SourcePool and Audio class are destroyed before tearing down Audio system.
  
## Caveats
Does this introduce any new bugs?
- None

## On approval
Merge
