### PR TITLE
Remove redundant struct and search through saves in new save system.

### DIFF
--- a/Phoenix/Client/Source/Game.cpp
+++ b/Phoenix/Client/Source/Game.cpp
@@ -76,31 +76,15 @@ Game::Game(gfx::Window* window, entt::registry* registry, bool networked)
 	}
 	// else TODO enable this else when we get mod list from network
 	//{
-	const std::string save = "save1";
+	auto saveToUse = "save1";
 	//}
 
-	std::fstream             fileStream;
-	std::vector<std::string> toLoad;
-
-	auto saveToUse = "save1234";
-	auto existingSaves = Save::listAllSaves();
-
-	if (std::find(existingSaves.begin(), existingSaves.end(), saveToUse) == existingSaves.end())
-	{
-		// gotta create a save, so we gotta give it a mod list too.
-
-		// we should use a mod list command line argument, but in the meantime
-		// lets hard code it.
-
-		std::vector<std::string> mods = {"mod1", "mod2", "mod3"};
-
-		m_save = new Save(saveToUse, mods);
-	}
-	else
-	{
-		// it exists so lets load it.
-		m_save = new Save(saveToUse);
-	}
+	// use this as a placeholder until we have command line arguments.
+	// even if the list is empty, it can create/load a save as required.
+	// listing mods but loading an existing save will NOT load more mods, you
+	// must manually edit the JSON to load an another mod after initialization.
+	std::vector<std::string> commandLineModList = {"mod1", "mod2", "mod3"};
+	m_save = new Save(saveToUse, commandLineModList);
 	
 	m_modManager = new cms::ModManager(m_save->getModList(), {"Modules"});
 

--- a/Phoenix/Common/Include/Common/Save.hpp
+++ b/Phoenix/Common/Include/Common/Save.hpp
@@ -44,25 +44,6 @@ namespace phx
 	};
 
 	/**
-	 * @brief Configuration for a Save.
-	 *
-	 * All these values are read through a JSON file in the save directory. If
-	 * the JSON file does not exist and/or the save itself doesn't exist, then a
-	 * save will be needed to be made.
-	 */
-	struct SaveConfig
-	{
-		// name of save.
-		std::string name;
-
-		// mod list, passed as CLI arguments.
-		std::vector<std::string> mods;
-
-		// save specific settings, etc...
-		nlohmann::json settings;
-	};
-
-	/**
 	 * @brief A class to handle data within a save.
 	 *
 	 * Saves will be directories inside the Save/ folder. The saves will contain
@@ -78,7 +59,8 @@ namespace phx
 		 * @param mods The mods to use if creating a save.
 		 * @param settings The settings to use if creating a save.
 		 */
-		Save(const std::string& save, const std::vector<std::string>& mods = {}, const nlohmann::json& settings = {});
+		Save(const std::string& save, const std::vector<std::string>& mods = {},
+		     const nlohmann::json& settings = {});
 
 		/**
 		 * @brief Saves everything to be saved and closes the save.
@@ -108,11 +90,11 @@ namespace phx
 		/// @todo Implement Dimension system.
 		/// keeping these empty methods so we know what we need, I'll work on
 		/// this fairly soon with worldgen probably. - beeper.
-		//Dimension* createDimension(const std::string& name);
-		//Dimension* getDimension(const std::string& name);
-		//void       setDefaultDimension(Dimension* dimension);
-		//Dimension* getDefaultDimension();
-		//const std::vector<std::string>& getDimensions() const;
+		// Dimension* createDimension(const std::string& name);
+		// Dimension* getDimension(const std::string& name);
+		// void       setDefaultDimension(Dimension* dimension);
+		// Dimension* getDefaultDimension();
+		// const std::vector<std::string>& getDimensions() const;
 
 		/**
 		 * @brief Saves everything to be saved in the Save.
@@ -126,7 +108,9 @@ namespace phx
 		void toFile(const std::string& name = "");
 
 	private:
-		SaveConfig m_config;
+		std::string              m_name;
+		std::vector<std::string> m_mods;
+		nlohmann::json           m_settings;
 
 		/**
 		 * @brief Tells the saving operations whether settings have changed.
@@ -138,7 +122,7 @@ namespace phx
 		 */
 		bool m_settingsChanged = false;
 
-		//Dimension* m_defaultDimension;
-		//std::unordered_map<std::string, Dimension> m_loadedDimensions;
+		// Dimension* m_defaultDimension;
+		// std::unordered_map<std::string, Dimension> m_loadedDimensions;
 	};
 } // namespace phx

--- a/Phoenix/Common/Source/Save.cpp
+++ b/Phoenix/Common/Source/Save.cpp
@@ -60,9 +60,9 @@ Save::Save(const std::string& save, const std::vector<std::string>& mods,
 		json << std::setw(4) << saveSettings;
 		json.close();
 
-		m_config.name = save;
-		m_config.mods = mods;
-		m_config.settings = settings;
+		m_name = save;
+		m_mods = mods;
+		m_settings = settings;
 	}
 	else
 	{
@@ -90,9 +90,9 @@ Save::Save(const std::string& save, const std::vector<std::string>& mods,
 			exit(EXIT_FAILURE);
 		}
 
-		m_config.mods     = saveSettings["mods"].get<std::vector<std::string>>();
-		m_config.name     = saveSettings["name"].get<std::string>();
-		m_config.settings = saveSettings["settings"].get<nlohmann::json>();
+		m_name     = saveSettings["name"].get<std::string>();
+		m_mods     = saveSettings["mods"].get<std::vector<std::string>>();
+		m_settings = saveSettings["settings"].get<nlohmann::json>();
 	}
 }
 
@@ -137,14 +137,14 @@ std::vector<std::string> Save::listAllSaves()
 	return saves;
 }
 
-const std::string& Save::getName() const { return m_config.name; }
+const std::string& Save::getName() const { return m_name; }
 
 const std::vector<std::string>& Save::getModList() const
 {
-	return m_config.mods;
+	return m_mods;
 }
 
-const nlohmann::json& Save::getSettings() const { return m_config.settings; }
+const nlohmann::json& Save::getSettings() const { return m_settings; }
 
 void Save::toFile(const std::string& name)
 {
@@ -152,9 +152,9 @@ void Save::toFile(const std::string& name)
 
 	// if the name is not empty or the name of the current save, choose to make
 	// a new save.
-	if (!name.empty() && name != m_config.name)
+	if (!name.empty() && name != m_name)
 	{
-		m_config.name = name;
+		m_name = name;
 
 		const auto path = fs::current_path() / "Saves" / name;
 
@@ -176,8 +176,8 @@ void Save::toFile(const std::string& name)
 			// write new json file.
 			nlohmann::json saveSettings;
 			saveSettings["name"] = name;
-			saveSettings["mods"] = m_config.mods;
-			saveSettings["settings"] = m_config.settings;
+			saveSettings["mods"] = m_mods;
+			saveSettings["settings"] = m_settings;
 
 			std::ofstream json(path / (name + ".json"));
 			json << std::setw(4) << saveSettings;
@@ -190,11 +190,11 @@ void Save::toFile(const std::string& name)
 
 			// write new json file.
 			nlohmann::json saveSettings;
-			saveSettings["name"]     = m_config.name;
-			saveSettings["mods"]     = m_config.mods;
-			saveSettings["settings"] = m_config.settings;
+			saveSettings["name"]     = m_name;
+			saveSettings["mods"]     = m_mods;
+			saveSettings["settings"] = m_settings;
 
-			std::ofstream json(path / (m_config.name + ".json"));
+			std::ofstream json(path / (m_name + ".json"));
 			json << std::setw(4) << saveSettings;
 			json.close();
 		}
@@ -204,7 +204,7 @@ void Save::toFile(const std::string& name)
 		// the save hasn't been renamed, and the settings have changed, now
 		// update file, otherwise there's no point.
 
-		const auto path = fs::current_path() / "Saves" / m_config.name;
+		const auto path = fs::current_path() / "Saves" / m_name;
 
 		// this exists as a error check to prevent an exception being thrown when opening the json file.
 		if (!fs::exists(path))
@@ -223,8 +223,8 @@ void Save::toFile(const std::string& name)
 		{
 			nlohmann::json saveSettings;
 			saveSettings["name"] = name;
-			saveSettings["mods"] = m_config.mods;
-			saveSettings["settings"] = m_config.settings;
+			saveSettings["mods"] = m_mods;
+			saveSettings["settings"] = m_settings;
 
 			std::ofstream writeSettings(path);
 			writeSettings << std::setw(4) << saveSettings;


### PR DESCRIPTION
Resolves: #
Authors:
@beeperdeeper089 

## Summary of changes
- Remove redundant SaveConfig struct.
- Remove redundant code when checking for saves to load since it would work anyway.
  
## Caveats
Does this introduce any new bugs?
- None

## On approval
Merge.