### PR TITLE
Fix issue where empty folder is still recognised as a save by the Save system.

### DIFF
--- a/Phoenix/Common/Source/Save.cpp
+++ b/Phoenix/Common/Source/Save.cpp
@@ -41,7 +41,10 @@ Save::Save(const std::string& save, const std::vector<std::string>& mods,
 	namespace fs = std::filesystem;
 
 	auto path = fs::current_path() / "Saves" / save;
-	if (!fs::exists(path))
+
+	// does not necessarily mean it's empty, it just means there's no save.json
+	// so we can do whatever.
+	if (!fs::exists(path / (save + ".json")))
 	{
 		LOG_INFO("SAVES") << "Save doesn't exist, creating.";
 		


### PR DESCRIPTION
Resolves: #
Authors:
@beeperdeeper089 

## Summary of changes
- Checks for the existance of a json within the folder, rather than just the folder.
  
## Caveats
Does this introduce any new bugs?
- It could be an issue if the folder doesn't have a json but has everything else. The save system might end up overwriting everything, however the likelyhood of this is low and I would be surprised if there is a valid situation for this to happen in.

## On approval
Merge.
