### PR TITLE
Update Sol2 to a newer version, drop MacOS CI.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 Build/
+out/
 
 .vs/
 .vscode/

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -64,14 +64,3 @@ jobs:
       displayName: 'CMake Configure'
     - script: cmake --build Build
       displayName: 'CMake Build'
-
-- job:
-  displayName: MacOSX
-  pool:
-    vmImage: 'macOS-latest'
-
-  steps:
-    - script: cmake -S . -B Build
-      displayName: 'CMake Configure'
-    - script: cmake --build Build
-      displayName: 'CMake Build'


### PR DESCRIPTION
Resolves: #
Authors:
@beeperdeeper089 

## Summary of changes
- Update Sol2 submodule.
- Drop MacOS CI temporarily since it's just a big pain in the arse.
  
## Caveats
Does this introduce any new bugs?
- lack of macos CI.

## On approval
Merge.