### PR TITLE
Move crosshair to Camera

### DIFF
--- a/Phoenix/Client/Include/Client/Game.hpp
+++ b/Phoenix/Client/Include/Client/Game.hpp
@@ -28,7 +28,6 @@
 
 #pragma once
 
-#include <Client/Crosshair.hpp>
 #include <Client/EscapeMenu.hpp>
 #include <Client/GameTools.hpp>
 
@@ -104,7 +103,6 @@ namespace phx::client
 
 		cms::ModManager* m_modManager;
 
-		Crosshair*  m_crosshair  = nullptr;
 		EscapeMenu* m_escapeMenu = nullptr;
 		GameTools*  m_gameDebug  = nullptr;
 		bool        m_followCam  = true;

--- a/Phoenix/Client/Include/Client/Graphics/Camera.hpp
+++ b/Phoenix/Client/Include/Client/Graphics/Camera.hpp
@@ -35,8 +35,8 @@
 
 #pragma once
 
+#include <Client/Crosshair.hpp>
 #include <Client/Graphics/Window.hpp>
-
 #include <Client/InputMap.hpp>
 
 #include <Common/Math/Math.hpp>
@@ -194,7 +194,8 @@ namespace phx::gfx
 		math::vec2 m_windowCentre;
 
 		// Also used by InputQueue to determine if camera is focused or not
-		std::atomic<bool> m_enabled;
+		std::atomic<bool>  m_enabled;
+		client::Crosshair* m_crosshair = nullptr;
 
 		Setting* m_settingSensitivity;
 

--- a/Phoenix/Client/Source/Game.cpp
+++ b/Phoenix/Client/Source/Game.cpp
@@ -300,9 +300,7 @@ void Game::onAttach()
 	m_renderPipeline.setMatrix("u_model", model);
 
 	LOG_INFO("MAIN") << "Register GUI";
-	m_crosshair  = new Crosshair(m_window);
 	m_escapeMenu = new EscapeMenu(m_window);
-	Client::get()->pushLayer(m_crosshair);
 
 	if (Client::get()->isDebugLayerActive())
 	{
@@ -339,12 +337,10 @@ void Game::onEvent(events::Event& e)
 			if (!m_camera->isEnabled())
 			{
 				Client::get()->pushLayer(m_escapeMenu);
-				Client::get()->popLayer(m_crosshair);
 			}
 			else
 			{
 				Client::get()->popLayer(m_escapeMenu);
-				Client::get()->pushLayer(m_crosshair);
 			}
 			e.handled = true;
 			break;

--- a/Phoenix/Client/Source/Graphics/Camera.cpp
+++ b/Phoenix/Client/Source/Graphics/Camera.cpp
@@ -26,6 +26,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+#include <Client/Client.hpp>
 #include <Client/Graphics/Camera.hpp>
 
 #include <Common/Position.hpp>
@@ -52,6 +53,9 @@ FPSCamera::FPSCamera(Window* window, entt::registry* registry)
 	    Settings::get()->add("Sensitivity", "camera:sensitivity", 50);
 	m_settingSensitivity->setMax(100);
 	m_settingSensitivity->setMin(1);
+
+	m_crosshair = new client::Crosshair(m_window);
+	client::Client::get()->pushLayer(m_crosshair);
 }
 
 void FPSCamera::setProjection(const math::mat4& projection)
@@ -104,11 +108,13 @@ void FPSCamera::enable(bool enabled)
 		// gain control of the cursor
 		m_window->setCursorState(gfx::CursorState::DISABLED);
 		m_window->setCursorPosition(m_windowCentre);
+		client::Client::get()->pushLayer(m_crosshair);
 	}
 	else
 	{
 		// release cursor for the user to do whatever they want.
 		m_window->setCursorState(gfx::CursorState::NORMAL);
+		client::Client::get()->popLayer(m_crosshair);
 	}
 
 	m_enabled = enabled;


### PR DESCRIPTION
Authors:
@apachano 

## Summary of changes
Moves crosshair layer handling to the camera enable function. This simplifies handling the crosshair allowing other layers to handle exiting and returning control to the camera without bloating game.cpp with extensive if statements in the event code. 
  
## Caveats
Does this introduce any new bugs?
- None

## On approval
Merge
