### PR TITLE
Make logger actually output to a file.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,21 +13,4 @@ endif()
 # Use folders.
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
-# Update git submodules.
-find_package(Git QUIET)
-if (GIT_FOUND AND EXISTS "${PROJECT_SOURCE_DIR}/.git")
-    option(UPDATE_SUBMODULES "Update git submodules during build." ON)
-    if(UPDATE_SUBMODULES)
-        message(STATUS "Updating git submodules.")
-        execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive
-                        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-                        RESULT_VARIABLE GIT_SUBMODULE_RESULT)
-        if(NOT GIT_SUBMODULE_RESULT EQUAL "0")
-            message(FATAL_ERROR "git submodule update --init --recursive failed with ${GIT_SUBMODULE_RESULT}, please checkout submodules.")
-        endif()
-    else()
-        message(STATUS "Git submodules set to manual update only, this can be changed with the UPDATE_SUBMODULES option.")
-    endif()
-endif()
-
 add_subdirectory(Phoenix)

--- a/Phoenix/Client/Source/Client.cpp
+++ b/Phoenix/Client/Source/Client.cpp
@@ -119,7 +119,9 @@ void Client::onEvent(events::Event e)
 void Client::run()
 {
 	Settings::get()->load("settings.txt");
-    LoggerConfig config;
+
+	LoggerConfig config;
+	config.logFile   = "PhoenixClient.log";
     config.verbosity = LogVerbosity::DEBUG;
     Logger::initialize(config);
 

--- a/Phoenix/Client/Source/Client.cpp
+++ b/Phoenix/Client/Source/Client.cpp
@@ -121,6 +121,7 @@ void Client::run()
 	Settings::get()->load("settings.txt");
 
 	LoggerConfig config;
+	config.logToFile = true;
 	config.logFile   = "PhoenixClient.log";
     config.verbosity = LogVerbosity::DEBUG;
     Logger::initialize(config);

--- a/Phoenix/Common/Include/Common/Logger.hpp
+++ b/Phoenix/Common/Include/Common/Logger.hpp
@@ -71,6 +71,7 @@ namespace phx
 		LogVerbosity verbosity    = LogVerbosity::INFO;
 		bool         threaded     = false;
 		bool         logToConsole = true;
+		bool         logToFile  = true;
 	};
 
 	class Log
@@ -139,8 +140,9 @@ namespace phx
 		std::thread             m_worker;
 		void                    loggerThreadHandle();
 
-		bool          m_logToConsole;
-		std::ofstream m_file;
+		bool       m_logToConsole;
+		bool       m_logToFile;
+		FILE*      m_file = nullptr;
 	};
 } // namespace phx
 

--- a/Phoenix/Common/Source/Logger.cpp
+++ b/Phoenix/Common/Source/Logger.cpp
@@ -31,12 +31,18 @@
 
 #ifdef ENGINE_PLATFORM_WINDOWS
 #	include <Windows.h>
+// supress warnings for fopen and FILE*
+#	define _CRT_SECURE_NO_WARNINGS
 #endif
 
 #include <cstdio>
+#include <cstring>
+#include <cmath>
 
 using namespace phx;
 
+// just the lengths of the strings for the verbosity texts,
+static const std::size_t g_logVerbToTextStringLength[] = {5, 7, 4, 5};
 static const char* g_logVerbToText[] = {"FATAL", "WARNING", "INFO", "DEBUG"};
 
 #ifdef ENGINE_PLATFORM_WINDOWS
@@ -172,6 +178,7 @@ Logger::Logger(const LoggerConfig& config)
 	m_threaded     = config.threaded;
 	m_verbosity    = config.verbosity;
 	m_logToConsole = config.logToConsole;
+	m_logToFile    = config.logToFile;
 
 	if (m_threaded)
 	{
@@ -180,17 +187,24 @@ Logger::Logger(const LoggerConfig& config)
 		m_worker.swap(thread);
 	}
 
-	m_file.open(config.logFile, std::ios_base::app);
-	if (!m_file.is_open())
+	if (m_logToFile)
 	{
-		Log message = {LogVerbosity::INFO, "", 0, "LOGGING"};
-		message << "A log file was not specified, logging only to console.";
-		log(message);
+		m_file = fopen(config.logFile.c_str(), "a");
+		if (m_file == nullptr)
+		{
+			m_logToFile = false;
+
+			Log message = {LogVerbosity::INFO, "", 0, "LOGGING"};
+			message << "A log file was not specified, logging only to console.";
+			log(message);
+
+		}
 	}
 }
 
 Logger::~Logger()
 {
+	// could use fwrite here, but printf does the job in a more readable way.
 	printf("\n");
 
 	if (m_threaded)
@@ -202,36 +216,74 @@ Logger::~Logger()
 			m_worker.join();
 	}
 
-	m_file.close();
+	if (m_logToFile)
+	{
+		fclose(m_file);
+	}
 }
 
 void Logger::loggerInternal(const Log& log)
 {
 	if (m_logToConsole)
 	{
+		// because you can't get the length of a stringstream????
+		std::string logStream = log.stream.str();
+
+		char* buffer = nullptr;
+
+		// the base structure will also always have the verb, component and
+		// actual stream.
+		//
+		// for info & release builds: [%s][%s] %s\n (6 base characters)
+		// for debug builds (verb != info): [%s][%s] %s:%d %s\n (9 base chars)
+		// the base structure will always have at least 6 format characters.
+		std::size_t length =
+		    g_logVerbToTextStringLength[static_cast<int>(log.verbosity)] +
+		    log.component.size() + logStream.size() + 6;
+
+#		ifdef ENGINE_DEBUG
+		if (log.verbosity != LogVerbosity::INFO)
+		{
+			// +3 since we've already added 6 base chars above, debug & !info
+			// messages have 9 so... 3 is the difference.
+			length +=
+			    3 + log.errorFile.size() + (std::log10(log.errorLine) + 1);
+		}
+#		endif
+		
+		// +1 because null terminator.
+		buffer = new char[length + 1];
+
 		if (log.verbosity == LogVerbosity::INFO)
 		{
-			setTerminalTextColor(LogVerbosity::INFO);
-			printf("[%s][%s] %s\n",
-			       g_logVerbToText[static_cast<int>(log.verbosity)],
-			       log.component.c_str(), log.stream.str().c_str());
-			setTerminalTextColor(TextColor::WHITE);
+			snprintf(buffer, length + 1, "[%s][%s] %s\n",
+			         g_logVerbToText[static_cast<int>(log.verbosity)],
+			         log.component.c_str(), log.stream.str().c_str());
 		}
 		else
 		{
-			setTerminalTextColor(log.verbosity);
 #ifdef ENGINE_DEBUG
-			printf("[%s] %s:%i [%s] %s\n",
-			       g_logVerbToText[static_cast<int>(log.verbosity)],
-			       log.errorFile.c_str(), log.errorLine, log.component.c_str(),
-			       log.stream.str().c_str());
-			setTerminalTextColor(TextColor::WHITE);
+			snprintf(buffer, length + 1, "[%s] %s:%i [%s] %s\n",
+			         g_logVerbToText[static_cast<int>(log.verbosity)],
+			         log.errorFile.c_str(), log.errorLine,
+			         log.component.c_str(), log.stream.str().c_str());
 #else
-			printf("[%s][%s] %s\n",
-			       g_logVerbToText[static_cast<int>(log.verbosity)],
-			       log.component.c_str(), log.stream.str().c_str());
-			setTerminalTextColor(TextColor::WHITE);
+			snprintf(buffer, length + 1, "[%s][%s] %s\n",
+			         g_logVerbToText[static_cast<int>(log.verbosity)],
+			         log.component.c_str(), log.stream.str().c_str());
 #endif
+		}
+
+		if (m_logToConsole)
+		{
+			setTerminalTextColor(log.verbosity);
+			fwrite(buffer, 1, length + 1, stdout);
+			setTerminalTextColor(TextColor::WHITE);
+		}
+
+		if (m_logToFile)
+		{
+			fwrite(buffer, 1, length + 1, m_file);
 		}
 	}
 }


### PR DESCRIPTION
Resolves: #
Authors:
@beeperdeeper089 

## Summary of changes
- Make logger output to file
- Get rid of cmake auto-updating submodules, since it slows down VS builds and was actually making my builds fail.
  
## Caveats
Does this introduce any new bugs?
- None

## On approval
Merge.