### PR TITLE
Feat items

### DIFF
--- a/Phoenix/Client/Include/Client/Game.hpp
+++ b/Phoenix/Client/Include/Client/Game.hpp
@@ -42,6 +42,7 @@
 #include <Client/InputQueue.hpp>
 #include <Client/HUD.hpp>
 
+#include <Client/Voxels/ItemRegistry.hpp>
 #include <Common/CMS/ModManager.hpp>
 #include <Common/Save.hpp>
 
@@ -90,6 +91,7 @@ namespace phx::client
 
 	private:
 		BlockRegistry m_blockRegistry;
+		ItemRegistry  m_itemRegistry;
 
 		entt::registry* m_registry;
 		entt::entity    m_player;

--- a/Phoenix/Client/Include/Client/Voxels/BlockRegistry.hpp
+++ b/Phoenix/Client/Include/Client/Voxels/BlockRegistry.hpp
@@ -63,7 +63,7 @@ namespace phx::client
 			textures.add(voxels::BlockType::UNKNOWN_BLOCK, "unknown.png");
 			textures.setUnknownReturnVal(
 			    textures.get(voxels::BlockType::UNKNOWN_BLOCK));
-			
+
 			models.add(voxels::BlockType::UNKNOWN_BLOCK,
 			           gfx::BlockModel::BLOCK);
 			models.setUnknownReturnVal(

--- a/Phoenix/Client/Include/Client/Voxels/CMakeLists.txt
+++ b/Phoenix/Client/Include/Client/Voxels/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(currentDir ${CMAKE_CURRENT_LIST_DIR})
 set(Headers
-	${currentDir}/BlockRegistry.hpp
-	
-	PARENT_SCOPE
-)
+		${currentDir}/BlockRegistry.hpp
+		${currentDir}/ItemRegistry.hpp
+
+		PARENT_SCOPE
+		)

--- a/Phoenix/Client/Include/Client/Voxels/ItemRegistry.hpp
+++ b/Phoenix/Client/Include/Client/Voxels/ItemRegistry.hpp
@@ -1,0 +1,118 @@
+// Copyright 2019-20 Genten Studios
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#include <Common/CMS/ModManager.hpp>
+#include <Common/Registry.hpp>
+#include <Common/Voxels/ItemReferrer.hpp>
+
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace phx::client
+{
+	/**
+	 * @brief Acts as a register for item data throughout the client
+	 * application.
+	 *
+	 * This holds a block referrer which handles default initialized blocks and
+	 * then provides an API registration for registering blocks from within Lua.
+	 */
+	struct ItemRegistry
+	{
+		voxels::ItemReferrer referrer;
+
+		void registerAPI(cms::ModManager* manager)
+		{
+			manager->registerFunction(
+			    "voxel.item.register", [manager, this](sol::table luaItem) {
+				    voxels::ItemType item;
+
+				    sol::optional<std::string> name = luaItem["name"];
+				    if (name)
+				    {
+					    item.displayName = *name;
+				    }
+				    else
+				    {
+					    // log the error and return to make this a recoverable
+					    // error.
+					    LOG_FATAL("MODDING")
+					        << "The mod at: " << manager->getCurrentModPath()
+					        << " attempted to register an item without "
+					        << "specifying a name.";
+					    return;
+				    }
+
+				    sol::optional<std::string> id = luaItem["id"];
+				    if (id)
+				    {
+					    item.id = luaItem.get<std::string>("id");
+				    }
+				    else
+				    {
+					    // log the error and return to make this a recoverable
+					    // error.
+					    LOG_FATAL("MODDING")
+					        << "The mod at: " << manager->getCurrentModPath()
+					        << " attempted to register an item ("
+					        << item.displayName
+					        << ") without specifying an id.";
+					    return;
+				    }
+
+				    sol::optional<std::string> places = luaItem["places"];
+				    if (places)
+				    {
+					    item.places = *places;
+				    }
+
+				    sol::optional<sol::function> onPlace = luaItem["onPlace"];
+				    if (onPlace)
+				    {
+					    item.onPlace = *onPlace;
+				    }
+
+				    sol::optional<sol::function> onInteract =
+				        luaItem["onInteract"];
+				    if (onInteract)
+				    {
+					    item.onInteract = *onInteract;
+				    }
+
+				    std::size_t itemUID   = referrer.referrer.size();
+				    item.uniqueIdentifier = itemUID;
+
+				    referrer.referrer.add(item.id, itemUID);
+				    referrer.items.add(itemUID, item);
+			    });
+		}
+	};
+} // namespace phx::client

--- a/Phoenix/Client/Source/Game.cpp
+++ b/Phoenix/Client/Source/Game.cpp
@@ -67,10 +67,11 @@ Game::Game(gfx::Window* window, entt::registry* registry, bool networked)
 	// must manually edit the JSON to load an another mod after initialization.
 	std::vector<std::string> commandLineModList = {"mod1", "mod2", "mod3"};
 	m_save = new Save(saveToUse, commandLineModList);
-	
+
 	m_modManager = new cms::ModManager(m_save->getModList(), {"Modules"});
 
 	m_blockRegistry.registerAPI(m_modManager);
+	m_itemRegistry.registerAPI(m_modManager);
 
 	m_modManager->registerFunction(
 	    "core.command.register",
@@ -142,8 +143,7 @@ void Game::onAttach()
 	m_camera = new gfx::FPSCamera(m_window, m_registry);
 	m_camera->setActor(m_player);
 
-	m_registry->emplace<Hand>(
-	    m_player, m_blockRegistry.referrer.blocks.get(0));
+	m_registry->emplace<Hand>(m_player, m_itemRegistry.referrer.items.get(2));
 
 	LOG_INFO("MAIN") << "Prepare rendering";
 
@@ -231,13 +231,13 @@ void Game::onEvent(events::Event& e)
 		case events::Keys::KEY_E:
 			m_playerHand++;
 			m_registry->get<Hand>(m_player).hand =
-			    m_blockRegistry.referrer.blocks.get(m_playerHand);
+			    m_itemRegistry.referrer.items.get(m_playerHand);
 			e.handled = true;
 			break;
 		case events::Keys::KEY_R:
 			m_playerHand--;
 			m_registry->get<Hand>(m_player).hand =
-			    m_blockRegistry.referrer.blocks.get(m_playerHand);
+			    m_itemRegistry.referrer.items.get(m_playerHand);
 			e.handled = true;
 			break;
 		case events::Keys::KEY_P:

--- a/Phoenix/Common/Include/Common/Actor.hpp
+++ b/Phoenix/Common/Include/Common/Actor.hpp
@@ -36,6 +36,7 @@
 #include <Common/Input.hpp>
 #include <Common/Voxels/Block.hpp>
 #include <Common/Voxels/BlockReferrer.hpp>
+#include <Common/Voxels/Item.hpp>
 
 #include <entt/entt.hpp>
 
@@ -43,7 +44,7 @@ namespace phx
 {
 	struct Hand
 	{
-		voxels::BlockType* hand;
+		voxels::ItemType* hand;
 	};
 
 	class ActorSystem

--- a/Phoenix/Common/Include/Common/Metadata.hpp
+++ b/Phoenix/Common/Include/Common/Metadata.hpp
@@ -49,6 +49,12 @@ namespace phx
 	{
 	public:
 		/**
+		 * @brief QOL "typedef" for use in implementations where metadata needs
+		 * stored in relation to indexed objects and this is obnoxious to type.
+		 */
+		using Container = std::unordered_map<std::size_t, Metadata>;
+
+		/**
 		 * @brief Sets or inserts metadata.
 		 * @param key The key associated with the metadata.
 		 * @return true If the data was set.

--- a/Phoenix/Common/Include/Common/Voxels/BlockReferrer.hpp
+++ b/Phoenix/Common/Include/Common/Voxels/BlockReferrer.hpp
@@ -96,6 +96,11 @@ namespace phx::voxels
 			    blocks.get(voxels::BlockType::UNKNOWN_BLOCK));
 		}
 
+		/**
+		 * @brief Gets a BlockType from the registry by its string ID.
+		 * @param id The string ID of the BlockType.
+		 * @return Pointer to the block matching the string ID.
+		 */
 		BlockType* getByID(const std::string& id)
 		{
 			return blocks.get(*referrer.get(id));

--- a/Phoenix/Common/Include/Common/Voxels/CMakeLists.txt
+++ b/Phoenix/Common/Include/Common/Voxels/CMakeLists.txt
@@ -1,11 +1,13 @@
 set(currentDir ${CMAKE_CURRENT_LIST_DIR})
 set(Headers
-	${Headers}
+        ${Headers}
 
-	${currentDir}/Block.hpp
-	${currentDir}/BlockReferrer.hpp
-	${currentDir}/Chunk.hpp
-	${currentDir}/Map.hpp
+        ${currentDir}/Block.hpp
+        ${currentDir}/BlockReferrer.hpp
+        ${currentDir}/Chunk.hpp
+        ${currentDir}/Map.hpp
+        ${currentDir}/Item.hpp
+        ${currentDir}/ItemReferrer.hpp
 
-	PARENT_SCOPE
-)
+        PARENT_SCOPE
+        )

--- a/Phoenix/Common/Include/Common/Voxels/Item.hpp
+++ b/Phoenix/Common/Include/Common/Voxels/Item.hpp
@@ -61,8 +61,8 @@ namespace phx::voxels
 	{
 	public:
 		// the base ItemReferrer object implements this.
-		static constexpr std::size_t UNKNOWN_ITEM       = 0;
-		static constexpr std::size_t OUT_OF_BOUNDS_ITEM = 1;
+		static constexpr std::size_t UNKNOWN_ITEM = 0;
+		static constexpr std::size_t INVALID_ITEM = 1;
 
 	public:
 		ItemType()  = default;

--- a/Phoenix/Common/Include/Common/Voxels/Item.hpp
+++ b/Phoenix/Common/Include/Common/Voxels/Item.hpp
@@ -1,0 +1,107 @@
+// Copyright 2019-20 Genten Studios
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#include <Common/Math/Math.hpp>
+
+#include <sol/sol.hpp>
+
+#include <Common/Metadata.hpp>
+#include <array>
+#include <functional>
+#include <string>
+
+namespace phx::voxels
+{
+	/**
+	 * @brief A callback function for when actions related to an Item occur.
+	 *
+	 * This "typedef" is just a QoL thing, it's much better than typing out
+	 * the whole definition each and every time. HOWEVER, this is also since
+	 * this is VERY likely to change as we further develop implementations
+	 * of this feature.
+	 */
+	using ItemCallback = sol::function;
+
+	/**
+	 * @brief The universal data for items.
+	 *
+	 * This stores any information that is consistent of items of the same
+	 * "Type" regardless of the number of instances of that item in the
+	 * world. For example a dirt block will have the same basic information
+	 * every time it exists in the world.
+	 */
+	class ItemType
+	{
+	public:
+		// the base ItemReferrer object implements this.
+		static constexpr std::size_t UNKNOWN_ITEM       = 0;
+		static constexpr std::size_t OUT_OF_BOUNDS_ITEM = 1;
+
+	public:
+		ItemType()  = default;
+		~ItemType() = default;
+
+		/// @brief The name of the item as displayed to the player.
+		std::string displayName;
+
+		/// @brief The unique id of the item, in the format of "mod.item".
+		std::string id;
+
+		/// @brief The unique *identifier* for the item, this is an internal
+		/// variable.
+		std::size_t uniqueIdentifier = -1;
+
+		/**
+		 * @brief The block that is placed when onPlace is called. If left
+		 * undefined, no block is placed.
+		 *
+		 * @note onPlace is still called regardless of if this is defined
+		 */
+		std::string places;
+
+		/// @brief Callback for when the secondary interaction button is called.
+		ItemCallback onPlace;
+
+		/// @brief Callback for when the primary interaction is called.
+		ItemCallback onInteract;
+	};
+
+	/**
+	 * @brief Container representing a single instance of an Item.
+	 *
+	 * This holds a pointer to the universal type of the item and either the
+	 * metadata for the item or a nullptr if there is none.
+	 */
+	struct Item
+	{
+		ItemType* type;
+		Metadata* metadata;
+	};
+} // namespace phx::voxels

--- a/Phoenix/Common/Include/Common/Voxels/Item.hpp
+++ b/Phoenix/Common/Include/Common/Voxels/Item.hpp
@@ -57,7 +57,7 @@ namespace phx::voxels
 	 * world. For example a dirt block will have the same basic information
 	 * every time it exists in the world.
 	 */
-	class ItemType
+	struct ItemType
 	{
 	public:
 		// the base ItemReferrer object implements this.

--- a/Phoenix/Common/Include/Common/Voxels/ItemReferrer.hpp
+++ b/Phoenix/Common/Include/Common/Voxels/ItemReferrer.hpp
@@ -28,82 +28,60 @@
 
 #pragma once
 
-#include <Common/Voxels/Block.hpp>
 #include <Common/Registry.hpp>
+#include <Common/Voxels/Item.hpp>
 
 #include <string>
 
 namespace phx::voxels
 {
 	/**
-	 * @brief Acts as a universal pairing between string and block.
+	 * @brief Acts as a universal pairing between string and item.
 	 *
-	 * This class is a universal struct that can be passed around to act as a minimal set of data.
+	 * This class is a universal struct that can be passed around to act as a
+	 * minimal set of data.
 	 *
-	 * Originally we had a BlockRegistry that was on the Client/Server but we
-	 * realised that things like the Server don't need to store data about
-	 * textures and the likes, so by only having this as a common piece between
-	 * the two, the Client and Server can store extra data that they actually
-	 * need and potentially reduce unnecessary memory usage.
-	 *
-	 * Each application implements their own BlockRegistry with a few more
-	 * pieces of data and lua registration methods.
+	 * Each application implements their own Registry with a few more pieces
+	 * of data and lua registration methods.
 	 */
-	struct BlockReferrer
+	struct ItemReferrer
 	{
 		/**
 		 * @brief Automatically implements the Unknown, Out of Bounds and Air
 		 * blocks as necessary.
 		 */
-		BlockReferrer()
+		ItemReferrer()
 		{
-			// this will be 0, which is equivalent to BlockType::UNKNOWN_BLOCK
-			auto              uid = referrer.size();
-			voxels::BlockType unknown;
-			unknown.displayName      = "Unknown Block";
+			// this will be 0, which is equivalent to ItemType::UNKNOWN_ITEM
+			auto             uid = referrer.size();
+			voxels::ItemType unknown;
+			unknown.displayName      = "Unknown Item";
 			unknown.id               = "core.unknown";
-			unknown.category         = voxels::BlockCategory::SOLID;
 			unknown.uniqueIdentifier = uid;
 			referrer.add(unknown.id, uid);
-			blocks.add(uid, unknown);
+			items.add(uid, unknown);
 
 			// this will be 1, which is equivalent to
-			// BlockType::OUT_OF_BOUNDS_BLOCK.
+			// ItemType::OUT_OF_BOUNDS_ITEM.
 			uid = referrer.size();
-			voxels::BlockType outOfBounds;
+			voxels::ItemType outOfBounds;
 			outOfBounds.displayName      = "Out of Bounds";
-			outOfBounds.id               = "core.out_ouf_bounds";
-			outOfBounds.category         = voxels::BlockCategory::AIR;
+			outOfBounds.id               = "core.out_of_bounds";
 			outOfBounds.uniqueIdentifier = uid;
 			referrer.add(outOfBounds.id, uid);
-			blocks.add(uid, outOfBounds);
-
-			// this will be 2, which is equivalent to BlockType::AIR_BLOCK.
-			uid = referrer.size();
-			voxels::BlockType air;
-			air.displayName      = "Air";
-			air.id               = "core.air";
-			air.category         = voxels::BlockCategory::AIR;
-			air.uniqueIdentifier = uid;
-			referrer.add(air.id, uid);
-			blocks.add(uid, air);
+			items.add(uid, outOfBounds);
 
 			// by default will return unknown blocks if they don't exist.
 			// a tiny bit hacky but solves a lot of problems without writing a
 			// bunch of unnecessary code.
 			referrer.setUnknownReturnVal(referrer.get("core.unknown"));
-			blocks.setUnknownReturnVal(
-			    blocks.get(voxels::BlockType::UNKNOWN_BLOCK));
+			items.setUnknownReturnVal(
+			    items.get(voxels::ItemType::UNKNOWN_ITEM));
 		}
 
-		BlockType* getByID(const std::string& id)
-		{
-			return blocks.get(*referrer.get(id));
-		};
-
 		// referrer refers a string to int, which in turn is used to get the
-		// blocktype.
+		// item type.
 		Registry<std::string, std::size_t> referrer;
-		Registry<std::size_t, BlockType>   blocks;
+		Registry<std::size_t, ItemType>    items;
 	};
 } // namespace phx::voxels

--- a/Phoenix/Common/Source/Actor.cpp
+++ b/Phoenix/Common/Source/Actor.cpp
@@ -163,34 +163,44 @@ bool ActorSystem::action2(entt::registry* registry, entt::entity entity)
 			math::vec3 back = ray.backtrace(RAY_INCREMENT);
 			back.floor();
 
-			voxels::Block block = {registry->get<Hand>(entity).hand, nullptr};
-			Metadata      data;
-			if (block.type->rotH)
+			voxels::ItemType* item = registry->get<Hand>(entity).hand;
+			if (!item->places.empty())
 			{
-				math::vec3 rotation = {};
-				if (dir.x > 0)
+				voxels::Block block {m_blockReferrer->getByID(item->places),
+				                     nullptr};
+				Metadata      data;
+				if (block.type->rotH)
 				{
-					rotation.x += 180;
+					math::vec3 rotation = {};
+					if (dir.x > 0)
+					{
+						rotation.x += 180;
+					}
+					if (dir.z > 0)
+					{
+						rotation.x += 90;
+					}
+					if (rotation.x > 0)
+					{
+						data.set("core.rotation", rotation);
+					}
 				}
-				if (dir.z > 0)
+				if (data.size() > 0)
 				{
-					rotation.x += 90;
+					block.metadata = &data;
 				}
-				if (rotation.x > 0)
+
+				map->setBlockAt(back, block);
+
+				// TODO move this to the map code
+				if (block.type->onPlace)
 				{
-					data.set("core.rotation", rotation);
+					block.type->onPlace(back.x, back.y, back.z);
 				}
 			}
-			if (data.size() > 0)
+			if (item->onPlace)
 			{
-				block.metadata = &data;
-			}
-
-			map->setBlockAt(back, block);
-
-			if (block.type->onPlace)
-			{
-				block.type->onPlace(back.x, back.y, back.z);
+				item->onPlace(back.x, back.y, back.z);
 			}
 
 			return true;

--- a/Phoenix/Common/Source/Actor.cpp
+++ b/Phoenix/Common/Source/Actor.cpp
@@ -171,7 +171,7 @@ bool ActorSystem::action2(entt::registry* registry, entt::entity entity)
 				Metadata      data;
 				if (block.type->rotH)
 				{
-					math::vec3 rotation = {};
+					math::vec3 rotation;
 					if (dir.x > 0)
 					{
 						rotation.x += 180;

--- a/Phoenix/Modules/mod1/Init.lua
+++ b/Phoenix/Modules/mod1/Init.lua
@@ -1,31 +1,40 @@
 core.log_info("Load mod 1")
 
-function hello (args)
-    if args[1] == "there" then
-        print("General Kenobi")
-    elseif args[1] == "world" then
-        print("World says hi")
-    else
-        print("with you, the force is not")
-    end
-end
+--function hello (args)
+--    if args[1] == "there" then
+--        print("General Kenobi")
+--    elseif args[1] == "world" then
+--        print("World says hi")
+--    else
+--        print("with you, the force is not")
+--    end
+--end
 
 --core.command.register("Hello", "Master the arts of the Jedi you must", hello)
 
-core.setting.register({name = "Test1", key = "Mod1.test1", default = 50, max = 100, min = 0})
-core.setting.register({name = "Test2", key = "Mod1.test2", default = 50, max = 100, min = 0})
-core.setting.register({name = "Test3", key = "Mod1.test3", default = 50, max = 100, min = 0})
+core.setting.register({ name = "Test1", key = "Mod1.test1", default = 50, max = 100, min = 0 })
+core.setting.register({ name = "Test2", key = "Mod1.test2", default = 50, max = 100, min = 0 })
+core.setting.register({ name = "Test3", key = "Mod1.test3", default = 50, max = 100, min = 0 })
 
-voxel.block.register({ name = "Dirt", id = "core.dirt", textures = { "Assets/dirt.png" } })
+function register_block_pair(_name, _id, _textures, _image)
+    local _obj = {
+        name = _name,
+        id = _id,
+        places = _id,
+        drops = _id,
+        textures = _textures,
+        image = _image
+    }
+    voxel.block.register(_obj)
+    voxel.item.register(_obj)
+end
 
-voxel.block.register({
-    name = "Grass",
-    id = "core.grass",
-    textures = {
+register_block_pair("Dirt", "core.dirt", { "Assets/dirt.png" }, "Assets/dirt.png")
+register_block_pair("Grass", "core.grass",
+    {
         "Assets/grass_side.png", "Assets/grass_side.png", "Assets/grass_side.png",
         "Assets/grass_side.png", "Assets/grass_top.png", "Assets/dirt.png"
-    }
-})
+    }, "Assets/grass_side.png")
 
 voxel.block.register({
     name = "Dirt Stair",


### PR DESCRIPTION
Authors:
@apachano 

## Summary of changes
- Implements base framework for item implementation
- Implements item registration through Lua
- Switches player hand from blocks to items
- Implements stored value for blocks dropping items
  
## Caveats
- Item and block places/drops store strings as arguments to allow for registration without the target existing
- Block drops functionality is not actually implemented

## QA Notes
- Functionally nothing should be different than before
- Only registered items are available for the hand selector, blocks should not be

## On approval
Merge
