### PR TITLE
Serialize consecutive metadata-less blocks with a quantity specifier.

### DIFF
--- a/Phoenix/Common/Include/Common/Voxels/Chunk.hpp
+++ b/Phoenix/Common/Include/Common/Voxels/Chunk.hpp
@@ -190,6 +190,10 @@ namespace phx::voxels
 		Serializer& operator<<(Serializer& ser) override;
 
 	private:
+		///@brief Utility function for serialization
+		bool canRepeat(std::size_t i) const;
+
+	private:
 		math::vec3                                m_pos;
 		BlockList                                 m_blocks;
 		std::unordered_map<std::size_t, Metadata> m_metadata;

--- a/Phoenix/Common/Source/Voxels/Chunk.cpp
+++ b/Phoenix/Common/Source/Voxels/Chunk.cpp
@@ -102,7 +102,8 @@ phx::Serializer& Chunk::operator>>(phx::Serializer& ser) const
 		{
 			std::size_t j;
 			for (j = 1; i + 1 < CHUNK_MAX_BLOCKS &&
-			            m_blocks[i + 1]->id == m_blocks[i]->id;
+			            m_blocks[i + 1]->id == m_blocks[i]->id &&
+			            m_metadata.find(i + 1) == m_metadata.end();
 			     j++)
 			{
 				i++;

--- a/Phoenix/Common/Source/Voxels/Chunk.cpp
+++ b/Phoenix/Common/Source/Voxels/Chunk.cpp
@@ -103,6 +103,7 @@ phx::Serializer& Chunk::operator>>(phx::Serializer& ser) const
 		         m_metadata.find(i + 1) == m_metadata.end())
 		{
 			std::size_t j = i;
+			i++;
 			while (i + 1 < CHUNK_MAX_BLOCKS &&
 			       m_blocks[i + 1]->id == m_blocks[i]->id &&
 			       m_metadata.find(i + 1) == m_metadata.end())

--- a/Phoenix/Common/Source/Voxels/Chunk.cpp
+++ b/Phoenix/Common/Source/Voxels/Chunk.cpp
@@ -113,7 +113,6 @@ phx::Serializer& Chunk::operator>>(phx::Serializer& ser) const
 		else if (canRepeat(i))
 		{
 			std::size_t j = i;
-			i++;
 			while (canRepeat(i))
 			{
 				i++;
@@ -155,10 +154,11 @@ phx::Serializer& Chunk::operator<<(phx::Serializer& ser)
 		{
 			std::size_t rep;
 			ser >> rep;
-			for (std::size_t j = 1; j < rep; j++)
+			for (std::size_t j = 0; j < rep; j++)
 			{
 				m_blocks.push_back(
 				    m_referrer->blocks.get(*m_referrer->referrer.get(id)));
+				i++;
 			}
 		}
 	}

--- a/Phoenix/Common/Source/Voxels/Chunk.cpp
+++ b/Phoenix/Common/Source/Voxels/Chunk.cpp
@@ -98,6 +98,17 @@ phx::Serializer& Chunk::operator>>(phx::Serializer& ser) const
 		{
 			ser << '+' << m_metadata.at(i);
 		}
+		else if (m_blocks[i + 1]->id == m_blocks[i]->id)
+		{
+			std::size_t j;
+			for (j = 1; i + 1 < CHUNK_MAX_BLOCKS &&
+			            m_blocks[i + 1]->id == m_blocks[i]->id;
+			     j++)
+			{
+				i++;
+			}
+			ser << '*' << j;
+		}
 		else
 		{
 			ser << ';';
@@ -128,6 +139,16 @@ phx::Serializer& Chunk::operator<<(phx::Serializer& ser)
 			Metadata data;
 			ser >> data;
 			m_metadata[i] = data;
+		}
+		else if (c == '*')
+		{
+			std::size_t rep;
+			ser >> rep;
+			for (std::size_t j = 1; j < rep; j++)
+			{
+				m_blocks.push_back(
+				    m_referrer->blocks.get(*m_referrer->referrer.get(id)));
+			}
 		}
 	}
 

--- a/Phoenix/Common/Source/Voxels/Chunk.cpp
+++ b/Phoenix/Common/Source/Voxels/Chunk.cpp
@@ -87,8 +87,20 @@ bool Chunk::setMetadataAt(const phx::math::vec3& position,
 	return false;
 }
 
+bool Chunk::canRepeat(std::size_t i) const
+{
+	if (i + 1 >= CHUNK_MAX_BLOCKS)
+		return false;
+	if (m_blocks[i + 1]->id != m_blocks[i]->id)
+		return false;
+	if (m_metadata.find(i + 1) != m_metadata.end())
+		return false;
+	return true;
+};
+
 phx::Serializer& Chunk::operator>>(phx::Serializer& ser) const
 {
+
 	ser << m_pos.x << m_pos.y << m_pos.z;
 	for (int i = 0; i < CHUNK_MAX_BLOCKS; i++)
 	// for (const BlockType* block : m_blocks)
@@ -98,15 +110,11 @@ phx::Serializer& Chunk::operator>>(phx::Serializer& ser) const
 		{
 			ser << '+' << m_metadata.at(i);
 		}
-		else if (i + 1 < CHUNK_MAX_BLOCKS &&
-		         m_blocks[i + 1]->id == m_blocks[i]->id &&
-		         m_metadata.find(i + 1) == m_metadata.end())
+		else if (canRepeat(i))
 		{
 			std::size_t j = i;
 			i++;
-			while (i + 1 < CHUNK_MAX_BLOCKS &&
-			       m_blocks[i + 1]->id == m_blocks[i]->id &&
-			       m_metadata.find(i + 1) == m_metadata.end())
+			while (canRepeat(i))
 			{
 				i++;
 			}

--- a/Phoenix/Common/Source/Voxels/Chunk.cpp
+++ b/Phoenix/Common/Source/Voxels/Chunk.cpp
@@ -98,17 +98,18 @@ phx::Serializer& Chunk::operator>>(phx::Serializer& ser) const
 		{
 			ser << '+' << m_metadata.at(i);
 		}
-		else if (m_blocks[i + 1]->id == m_blocks[i]->id)
+		else if (i + 1 < CHUNK_MAX_BLOCKS &&
+		         m_blocks[i + 1]->id == m_blocks[i]->id &&
+		         m_metadata.find(i + 1) == m_metadata.end())
 		{
-			std::size_t j;
-			for (j = 1; i + 1 < CHUNK_MAX_BLOCKS &&
-			            m_blocks[i + 1]->id == m_blocks[i]->id &&
-			            m_metadata.find(i + 1) == m_metadata.end();
-			     j++)
+			std::size_t j = i;
+			while (i + 1 < CHUNK_MAX_BLOCKS &&
+			       m_blocks[i + 1]->id == m_blocks[i]->id &&
+			       m_metadata.find(i + 1) == m_metadata.end())
 			{
 				i++;
 			}
-			ser << '*' << j;
+			ser << '*' << i - j;
 		}
 		else
 		{


### PR DESCRIPTION
Resolves: None - Checks box 1 on #194 
Authors:
@apachano 

## Summary of changes
- When serializing a chunk, if two or more blocks have the same ID and no metadata we serialize a '*' character followed by the number of blocks that meet this criteria massively reducing the data used for chunks of mostly the same block. 
  
## Caveats
None

## QA Notes
- Save file size should be reduced
- Everything else should function the same

## On approval
Merge
