### PR TITLE
Fix missing include for iomanip in Settings.cpp

### DIFF
--- a/Phoenix/Common/Source/Settings.cpp
+++ b/Phoenix/Common/Source/Settings.cpp
@@ -31,6 +31,7 @@
 #include <climits>
 #include <fstream>
 #include <filesystem>
+#include <iomanip>
 #include <iostream>
 #include <string>
 


### PR DESCRIPTION
Resolves: Compilation error in GCC 3.8 from undefined setw symbol.
Authors:
@JosiahWI 

## Summary of changes
- The iomanip header is included in Settings.cpp
  
## Caveats
- None

## On approval
Merge
