### PR TITLE
Use the array delete instead of the improper delete

### DIFF
--- a/Phoenix/Client/Source/Graphics/ChatBox.cpp
+++ b/Phoenix/Client/Source/Graphics/ChatBox.cpp
@@ -44,7 +44,7 @@ ChatBox::ChatBox(Window* window, phx::BlockingQueue<std::string>* messageQueue)
 	std::memset(m_input, 0, MAX_INPUT_LIMIT);
 }
 
-ChatBox::~ChatBox() { delete m_input; }
+ChatBox::~ChatBox() { delete[] m_input; }
 
 void ChatBox::setDrawBox(bool drawBox) { m_drawBox = drawBox; }
 


### PR DESCRIPTION
Resolves: When deleting an array delete[] should be used or it will not be properly deleted.
Authors:
@JosiahWI

## Summary of changes
- An array allocated by the ChatBox is now deleted using delete[] instead of delete.
  
## Caveats


## On approval
Merge
