### PR TITLE
Fix a plethora of crashes when closing the game.

### DIFF
--- a/Phoenix/Client/Include/Client/Client.hpp
+++ b/Phoenix/Client/Include/Client/Client.hpp
@@ -61,8 +61,8 @@ namespace phx::client
 
 		entt::registry m_registry;
 
-		gfx::Window     m_window;
 		gfx::LayerStack m_layerStack;
+		gfx::Window     m_window;
 
 		bool          m_debugOverlayActive = false;
 		DebugOverlay* m_debugOverlay       = nullptr;

--- a/Phoenix/Client/Source/EscapeMenu.cpp
+++ b/Phoenix/Client/Source/EscapeMenu.cpp
@@ -65,7 +65,7 @@ void EscapeMenu::onEvent(phx::events::Event& e)
 			switch (m_page)
 			{
 			case Page::MAIN:
-				Client::get()->popLayer(this);
+				signalRemoval();
 				e.handled = true;
 				break;
 			case Page::SETTINGS:
@@ -102,7 +102,7 @@ void EscapeMenu::tick(float dt)
 		}
 		if (ImGui::Button("Return", {290, 30}))
 		{
-			Client::get()->popLayer(this);
+			signalRemoval();
 		}
 		if (ImGui::Button("Exit", {290, 30}))
 		{

--- a/Phoenix/Client/Source/Graphics/Camera.cpp
+++ b/Phoenix/Client/Source/Graphics/Camera.cpp
@@ -104,13 +104,11 @@ void FPSCamera::enable(bool enabled)
 		// gain control of the cursor
 		m_window->setCursorState(gfx::CursorState::DISABLED);
 		m_window->setCursorPosition(m_windowCentre);
-		client::Client::get()->pushLayer(m_crosshair);
 	}
 	else
 	{
 		// release cursor for the user to do whatever they want.
 		m_window->setCursorState(gfx::CursorState::NORMAL);
-		client::Client::get()->popLayer(m_crosshair);
 	}
 
 	m_enabled = enabled;

--- a/Phoenix/Common/Source/Actor.cpp
+++ b/Phoenix/Common/Source/Actor.cpp
@@ -164,6 +164,11 @@ bool ActorSystem::action2(entt::registry* registry, entt::entity entity)
 			back.floor();
 
 			voxels::ItemType* item = registry->get<Hand>(entity).getHand().type;
+			if (!item)
+			{
+				return false;
+			}
+			
 			if (!item->places.empty())
 			{
 				voxels::Block block {m_blockReferrer->getByID(item->places),
@@ -198,6 +203,7 @@ bool ActorSystem::action2(entt::registry* registry, entt::entity entity)
 					block.type->onPlace(back.x, back.y, back.z);
 				}
 			}
+
 			if (item->onPlace)
 			{
 				item->onPlace(back.x, back.y, back.z);


### PR DESCRIPTION
Resolves: #
Authors:
@beeperdeeper089 

## Summary of changes
- Fix crash when placing block
- Fix crash when closing game normally
- Fix crash when closing game with inventory or escape menu open.
  
## Caveats
Does this introduce any new bugs?
- None.

## On approval
Merge.