### PR TITLE
Group third party libraries together in an interface target

### DIFF
--- a/Phoenix/CMakeLists.txt
+++ b/Phoenix/CMakeLists.txt
@@ -1,8 +1,6 @@
 add_subdirectory(ThirdParty)
 
 # propagate these variables down the line into the child CMakeLists.
-set(PHX_THIRD_PARTY_LIBRARIES ${PHX_THIRD_PARTY_LIBRARIES})
-set(PHX_THIRD_PARTY_INCLUDES ${PHX_THIRD_PARTY_INCLUDES})
 set(PHX_COMMON_INCLUDES ${CMAKE_CURRENT_LIST_DIR}/Common/Include)
 
 add_subdirectory(Client)

--- a/Phoenix/Client/CMakeLists.txt
+++ b/Phoenix/Client/CMakeLists.txt
@@ -8,14 +8,13 @@ add_executable(${PROJECT_NAME} ${Headers} ${Sources})
 target_link_libraries(${PROJECT_NAME}
 	PRIVATE
 		PhoenixCommon
-		${PHX_THIRD_PARTY_LIBRARIES}
+		PhoenixThirdParty
 		$<$<AND:$<CXX_COMPILER_ID:GNU>,$<VERSION_LESS:$<CXX_COMPILER_VERSION>,9.0>>:stdc++fs>
 )
 
 target_include_directories(${PROJECT_NAME}
 	PRIVATE
 		Include
-		${PHX_THIRD_PARTY_INCLUDES}
 )
 
 set_target_properties(${PROJECT_NAME} PROPERTIES

--- a/Phoenix/Common/CMakeLists.txt
+++ b/Phoenix/Common/CMakeLists.txt
@@ -9,13 +9,11 @@ add_library(${PROJECT_NAME} STATIC ${Headers} ${Sources})
 
 target_link_libraries(${PROJECT_NAME}
 	PRIVATE
-	${PHX_THIRD_PARTY_LIBRARIES}
+	PhoenixThirdParty
 	$<$<AND:$<CXX_COMPILER_ID:GNU>,$<VERSION_LESS:$<CXX_COMPILER_VERSION>,9.0>>:stdc++fs>
 	)
 
 target_include_directories(${PROJECT_NAME}
-	PRIVATE
-	${PHX_THIRD_PARTY_INCLUDES}
 	PUBLIC
 	Include
 	)
@@ -32,14 +30,12 @@ if (PHX_BUILD_TESTS)
 
 	target_link_libraries(${PROJECT_NAME}_test
 		PRIVATE
-		${PHX_THIRD_PARTY_LIBRARIES}
+		PhoenixThirdParty
 		Catch2::Catch2
 		$<$<AND:$<CXX_COMPILER_ID:GNU>,$<VERSION_LESS:$<CXX_COMPILER_VERSION>,9.0>>:stdc++fs>
 		)
 
 	target_include_directories(${PROJECT_NAME}_test
-		PRIVATE
-		${PHX_THIRD_PARTY_INCLUDES}
 		PUBLIC
 		Include
 		)

--- a/Phoenix/Server/CMakeLists.txt
+++ b/Phoenix/Server/CMakeLists.txt
@@ -8,14 +8,13 @@ add_executable(${PROJECT_NAME} ${Headers} ${Sources})
 target_link_libraries(${PROJECT_NAME}
 	PRIVATE
 		PhoenixCommon
-		${PHX_THIRD_PARTY_LIBRARIES}
+		PhoenixThirdParty
 		$<$<AND:$<CXX_COMPILER_ID:GNU>,$<VERSION_LESS:$<CXX_COMPILER_VERSION>,9.0>>:stdc++fs>
 )
 
 target_include_directories(${PROJECT_NAME}
 	PRIVATE
 		Include
-		${PHX_THIRD_PARTY_INCLUDES}
 )
 
 set_target_properties(${PROJECT_NAME} PROPERTIES

--- a/Phoenix/ThirdParty/CMakeLists.txt
+++ b/Phoenix/ThirdParty/CMakeLists.txt
@@ -1,12 +1,12 @@
-# SDL needs this variable set, who knows why.
-set(HAVE_LIBC TRUE)
-
 # SDL2 setup
 # Exposes targets SDL2main and SDL2-static
-add_subdirectory(SDL2)
+
+set(HAVE_LIBC TRUE)
 
 # Make SDL build ONLY the static lib, we don't use the shared lib.
 set(SDL_SHARED_ENABLED_BY_DEFAULT OFF)
+
+add_subdirectory(SDL2)
 
 # Stop SDL trying to control our main function.
 target_compile_definitions(SDL2main INTERFACE SDL_MAIN_HANDLED)

--- a/Phoenix/ThirdParty/CMakeLists.txt
+++ b/Phoenix/ThirdParty/CMakeLists.txt
@@ -1,76 +1,107 @@
+# SDL2 setup
+# Exposes targets SDL2main and SDL2-static
+add_subdirectory(SDL2)
+
 set(HAVE_LIBC TRUE)
 
-# make SDL build ONLY the static lib, we don't use the shared lib.
+# Make SDL build ONLY the static lib, we don't use the shared lib.
 set(SDL_SHARED_ENABLED_BY_DEFAULT OFF)
-
-# turn off the JSON tests
-set(JSON_BuildTests OFF CACHE INTERNAL "")
-
-# turn off the EnTT tests.
-set(BUILD_TESTING OFF)
-
-
-add_subdirectory(SDL2)
-add_subdirectory(Glad)
-add_subdirectory(ImGui)
-add_subdirectory(sol2)
-add_subdirectory(lua)
-add_subdirectory(enet)
-add_subdirectory(entt)
-add_subdirectory(json)
-add_subdirectory(Catch2)
-# IDEFK what I am doing - this made SoLoud work. TODO: Fix this disaster
-set(SDL2_INCLUDE_DIR ${CMAKE_CURRENT_LIST_DIR}/SDL2/include)
-set(SDL2_LIBRARY SDL2main)
-add_subdirectory(soloud/contrib)
 
 # Stop SDL trying to control our main function.
 target_compile_definitions(SDL2main INTERFACE SDL_MAIN_HANDLED)
+
+# IDEFK what I am doing - this made SoLoud work. TODO: Fix this disaster
+set(SDL2_INCLUDE_DIR ${CMAKE_CURRENT_LIST_DIR}/SDL2/include)
+set(SDL2_LIBRARY SDL2main)
+
+# Glad setup
+# Exposes target Glad
+add_subdirectory(Glad)
+
+# ImGui setup
+# Exposes target ImGui
+add_subdirectory(ImGui)
+
+# sol2 setup
+# Exposes target sol2::sol2
+add_subdirectory(sol2)
+
+target_compile_options(sol2 INTERFACE
+  $<$<CXX_COMPILER_ID:MSVC>:/wd4996>
+  $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-W>
+)
+
+# lua setup
+# Exposes target liblua
+add_subdirectory(lua)
+
+# enet setup
+# Exposes target enet
+add_subdirectory(enet)
+
+# EnTT setup
+# Exposes target EnTT::EnTT
+add_subdirectory(entt)
+
 # NOMINMAX setting required for std::min std::max to work properly on Windows.
 target_compile_definitions(EnTT INTERFACE $<$<PLATFORM_ID:Windows>:NOMINMAX>)
+
+# Turn off the EnTT tests.
+set(BUILD_TESTING OFF)
+
+# Turn off the JSON tests.
+set(JSON_BuildTests OFF CACHE INTERNAL "")
+
+# JSON setup
+# Exposes target nlohmann_json::nlohmann_json
+add_subdirectory(json)
+
+# Catch2 setup
+# Exposes target Catch2::Catch2
+add_subdirectory(Catch2)
+
+# soloud setup
+# Exposes target soloud
+add_subdirectory(soloud/contrib)
+
+# Soloud requires SSE3 instructions.
+set_target_properties(soloud PROPERTIES
+	COMPILE_OPTIONS "-msse3"
+)
+
+# Create interface target to represent all internal dependencies.
+add_library(PhoenixThirdParty INTERFACE)
+target_link_libraries(PhoenixThirdParty INTERFACE
+	SDL2-static
+	SDL2main
+	Glad
+	ImGui
+	enet
+	EnTT::EnTT
+	sol2::sol2
+	soloud
+	liblua
+	nlohmann_json::nlohmann_json
+
+	$<$<PLATFORM_ID:Windows>:opengl32.lib> # link to opengl32.lib if windows.
+	$<$<PLATFORM_ID:Windows>:ws2_32.lib> # link to ws2_32.lib if windows.
+	$<$<PLATFORM_ID:Windows>:winmm.lib> # link to winmm.lib if windows.
+)
+
+target_include_directories(PhoenixThirdParty INTERFACE
+	${CMAKE_CURRENT_LIST_DIR}/Glad/include
+	${CMAKE_CURRENT_LIST_DIR}/ImGui
+	${CMAKE_CURRENT_LIST_DIR}/ImGui/examples
+	${CMAKE_CURRENT_LIST_DIR}/enet/include
+	${CMAKE_CURRENT_LIST_DIR}/soloud/include
+	${CMAKE_CURRENT_LIST_DIR}/stb_image
+	${CMAKE_CURRENT_LIST_DIR}/stb_rectpack
+)
 
 # new line for each group of dependencies. Currently SDL, OpenGL, Lua and then OpenAL.
 set_target_properties(SDL2main SDL2-static uninstall
 	Glad ImGui
 	lua liblua
 	enet aob
-	PROPERTIES FOLDER Dependencies)
-
-# utility thing to make phoenix cmake tidier
-set(PHX_THIRD_PARTY_INCLUDES
-	${CMAKE_CURRENT_LIST_DIR}/SDL2/include
-	${CMAKE_CURRENT_LIST_DIR}/Glad/include
-	${CMAKE_CURRENT_LIST_DIR}/ImGui
-	${CMAKE_CURRENT_LIST_DIR}/ImGui/examples
-	${CMAKE_CURRENT_LIST_DIR}/lua
-	${CMAKE_CURRENT_LIST_DIR}/enet/include
-	${CMAKE_CURRENT_LIST_DIR}/sol2/include
-	${CMAKE_CURRENT_LIST_DIR}/stb_image
-	${CMAKE_CURRENT_LIST_DIR}/stb_rectpack
-	${CMAKE_CURRENT_LIST_DIR}/entt/src
-	${CMAKE_CURRENT_LIST_DIR}/json/include
-	${CMAKE_CURRENT_LIST_DIR}/soloud/include
-
-	PARENT_SCOPE
-	)
-
-set(PHX_THIRD_PARTY_LIBRARIES
-	SDL2-static
-	SDL2main
-	Glad
-	ImGui
-	enet
-	sol2
-	soloud
-	liblua
-	nlohmann_json::nlohmann_json
-	$<$<PLATFORM_ID:Windows>:opengl32.lib> # link to opengl32.lib if windows.
-	$<$<PLATFORM_ID:Windows>:ws2_32.lib> # link to ws2_32.lib if windows.
-	$<$<PLATFORM_ID:Windows>:winmm.lib> # link to winmm.lib if windows.
-	PARENT_SCOPE
-	)
-
-target_compile_options(sol2 INTERFACE
-  $<$<CXX_COMPILER_ID:MSVC>:/wd4996>
-  $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-W>
+	PROPERTIES FOLDER Dependencies
 )

--- a/Phoenix/ThirdParty/CMakeLists.txt
+++ b/Phoenix/ThirdParty/CMakeLists.txt
@@ -1,8 +1,9 @@
+# SDL needs this variable set, who knows why.
+set(HAVE_LIBC TRUE)
+
 # SDL2 setup
 # Exposes targets SDL2main and SDL2-static
 add_subdirectory(SDL2)
-
-set(HAVE_LIBC TRUE)
 
 # Make SDL build ONLY the static lib, we don't use the shared lib.
 set(SDL_SHARED_ENABLED_BY_DEFAULT OFF)


### PR DESCRIPTION
Resolves: 
Authors:
@JosiahWI 

## Summary of changes
- The variables for third party libraries and headers were removed, and replaced with a single
- interface target PhoenixThirdParty that links the appropriate libraries.
- Some include directories are also added to the target because their respective projects were
- too lazy to add include directories to their targets.
  
## Caveats

## On approval
Merge
