### PR TITLE
Fix segfault on re-opening escape menu

### DIFF
--- a/Phoenix/Client/Include/Client/EscapeMenu.hpp
+++ b/Phoenix/Client/Include/Client/EscapeMenu.hpp
@@ -57,6 +57,8 @@ namespace phx::client
 		void tick(float dt) override;
 
 		bool isActive() { return m_active; };
+		void enableMenu();
+		void disableMenu();
 
 		static constexpr float WIDTH  = 300;
 		static constexpr float HEIGHT = 300;

--- a/Phoenix/Client/Include/Client/Voxels/CMakeLists.txt
+++ b/Phoenix/Client/Include/Client/Voxels/CMakeLists.txt
@@ -1,7 +1,9 @@
 set(currentDir ${CMAKE_CURRENT_LIST_DIR})
 set(Headers
-		${currentDir}/BlockRegistry.hpp
-		${currentDir}/ItemRegistry.hpp
+	${Headers}
 
-		PARENT_SCOPE
-		)
+	${currentDir}/BlockRegistry.hpp
+	${currentDir}/ItemRegistry.hpp
+
+	PARENT_SCOPE
+)

--- a/Phoenix/Client/Source/EscapeMenu.cpp
+++ b/Phoenix/Client/Source/EscapeMenu.cpp
@@ -42,20 +42,16 @@ EscapeMenu::EscapeMenu(phx::gfx::Window* window, phx::gfx::FPSCamera* camera)
 	m_settings = Settings::instance()->getImplFinalSettings();
 }
 
-void EscapeMenu::onAttach()
-{
-	m_page = Page::MAIN;
+void EscapeMenu::onAttach() {}
+void EscapeMenu::onDetach() {}
 
-	m_camera->enable(false);
-	m_active = true;
-}
-void EscapeMenu::onDetach()
-{
-	m_active = false;
-	m_camera->enable(true);
-}
 void EscapeMenu::onEvent(phx::events::Event& e)
 {
+	if (!m_active)
+	{
+		return;
+	}
+	
 	switch (e.type)
 	{
 	case phx::events::EventType::KEY_PRESSED:
@@ -65,7 +61,7 @@ void EscapeMenu::onEvent(phx::events::Event& e)
 			switch (m_page)
 			{
 			case Page::MAIN:
-				signalRemoval();
+				disableMenu();
 				e.handled = true;
 				break;
 			case Page::SETTINGS:
@@ -83,6 +79,11 @@ void EscapeMenu::onEvent(phx::events::Event& e)
 
 void EscapeMenu::tick(float dt)
 {
+	if (!m_active)
+	{
+		return;
+	}
+	
 	constexpr static double   DoubleMax = 100.0;
 	constexpr static double   DoubleMin = 0.0;
 	constexpr static uint64_t IntMax    = 100;
@@ -102,7 +103,7 @@ void EscapeMenu::tick(float dt)
 		}
 		if (ImGui::Button("Return", {290, 30}))
 		{
-			signalRemoval();
+			disableMenu();
 		}
 		if (ImGui::Button("Exit", {290, 30}))
 		{
@@ -156,4 +157,18 @@ void EscapeMenu::tick(float dt)
 	}
 
 	ImGui::End();
+}
+
+void EscapeMenu::enableMenu()
+{
+	m_page = Page::MAIN;
+
+	m_active = true;
+	m_camera->enable(false);
+}
+
+void EscapeMenu::disableMenu()
+{
+	m_active = false;
+	m_camera->enable(true);
 }

--- a/Phoenix/Client/Source/Game.cpp
+++ b/Phoenix/Client/Source/Game.cpp
@@ -188,6 +188,9 @@ void Game::onAttach()
 	m_hud = new HUD(m_window, m_registry, m_player);
 	Client::get()->pushLayer(m_hud);
 
+	m_escapeMenu = new EscapeMenu(m_window, m_camera);
+	Client::get()->pushLayer(m_escapeMenu);
+	
 	m_inputQueue = new InputQueue(m_registry, m_player, m_camera);
 	if (m_network != nullptr)
 	{
@@ -213,7 +216,8 @@ void Game::onEvent(events::Event& e)
 		switch (e.keyboard.key)
 		{
 		case events::Keys::KEY_ESCAPE:
-			Client::get()->pushLayer(m_escapeMenu);
+			// on attach sets the m_active variable to true which renders the escape menu.
+			m_escapeMenu->enableMenu();
 			e.handled = true;
 			break;
 


### PR DESCRIPTION
Resolves: #
Authors:
@beeperdeeper089 

## Summary of changes
- Doesn't remove the EscapeMenu from the stack anymore, but rather just disables it and re-enables it when necessary.
  
## Caveats
Does this introduce any new bugs?
- None.

## On approval
Merge.