### PR TITLE
Refactor map to be member of save object

### DIFF
--- a/Phoenix/Client/Include/Client/Game.hpp
+++ b/Phoenix/Client/Include/Client/Game.hpp
@@ -107,9 +107,6 @@ namespace phx::client
 		voxels::Inventory* m_playerInventory = nullptr;
 		int                m_playerHand      = 0;
 
-		voxels::Map*              m_map        = nullptr;
-		voxels::InventoryManager* m_invManager = nullptr;
-
 		SoLoud::Soloud m_soloud;
 
 		gfx::Window*        m_window;
@@ -136,6 +133,8 @@ namespace phx::client
 		// This is an internal log of the recent input states sent to the server
 		std::list<InputState> m_states;
 
-		Save* m_save = nullptr;
+        Save* m_save = nullptr;
+        voxels::Map*              m_map        = nullptr;
+        voxels::InventoryManager* m_invManager = nullptr;
 	};
 } // namespace phx::client

--- a/Phoenix/Client/Source/Game.cpp
+++ b/Phoenix/Client/Source/Game.cpp
@@ -125,12 +125,12 @@ Game::~Game()
 
 void Game::onAttach()
 {
-	if (m_network != nullptr)
+	if (m_network)
 	{
 		m_network->start();
 	}
 
-	m_player = ActorSystem::registerActor(m_registry);
+    LOG_INFO("MAIN") << "Loading Modules";
 
 	float progress = 0.f;
 	auto  result   = m_modManager->load(&progress);
@@ -142,30 +142,24 @@ void Game::onAttach()
 	}
 
 	LOG_INFO("MAIN") << "Registering world";
-	if (m_network != nullptr)
+	if (m_network)
 	{
+        m_chat = new gfx::ChatBox(m_window, &m_network->messageQueue);
 		m_map =
 		    new voxels::Map(&m_network->chunkQueue, &m_blockRegistry.referrer);
 	}
 	else
 	{
-		m_map = new voxels::Map(m_save, "map1", &m_blockRegistry.referrer);
+        m_chat = new gfx::ChatBox(m_window, nullptr);
+		m_map = m_save->getOrCreateMap("Map1", &m_blockRegistry.referrer);
 	}
 	m_invManager =
 	    new voxels::InventoryManager(m_save, &m_itemRegistry.referrer);
 	m_playerInventory =
 	    m_invManager->getInventory(m_invManager->createInventory(30));
+
+    m_player = ActorSystem::registerActor(m_registry);
 	m_registry->emplace<Hand>(m_player, 1, m_playerInventory);
-
-	if (m_network)
-	{
-		m_chat = new gfx::ChatBox(m_window, &m_network->messageQueue);
-	}
-	else
-	{
-		m_chat = new gfx::ChatBox(m_window, nullptr);
-	}
-
 	m_registry->emplace<PlayerView>(m_player, m_map);
 	m_camera = new gfx::FPSCamera(m_window, m_registry);
 	m_camera->setActor(m_player);
@@ -229,6 +223,7 @@ void Game::onDetach()
 	delete m_mapRenderer;
 	delete m_inputQueue;
 	delete m_network;
+    delete m_save;
 	delete m_camera;
 	delete m_audioEventHandler;
 }

--- a/Phoenix/Common/Include/Common/Save.hpp
+++ b/Phoenix/Common/Include/Common/Save.hpp
@@ -28,10 +28,11 @@
 
 #pragma once
 
-#include <Common/Voxels/Chunk.hpp>
+#include <Common/Voxels/Map.hpp>
 
 #include <nlohmann/json.hpp>
 
+#include <filesystem>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -40,11 +41,6 @@ namespace phx
 {
 
 	inline constexpr const char* saveDir {"Saves/"};
-
-	// temporary class until map is updated.
-	class Dimension
-	{
-	};
 
 	/**
 	 * @brief A class to handle data within a save.
@@ -90,14 +86,11 @@ namespace phx
 		 */
 		const nlohmann::json& getSettings() const;
 
-		/// @todo Implement Dimension system.
-		/// keeping these empty methods so we know what we need, I'll work on
-		/// this fairly soon with worldgen probably. - beeper.
-		// Dimension* createDimension(const std::string& name);
-		// Dimension* getDimension(const std::string& name);
-		// void       setDefaultDimension(Dimension* dimension);
-		// Dimension* getDefaultDimension();
-		// const std::vector<std::string>& getDimensions() const;
+        voxels::Map* getOrCreateMap(const std::string& name,
+                                    voxels::BlockReferrer* referrer);
+//		void         setDefaultMap(voxels::Map* map);
+//      voxels::Map* getDefaultMap();
+//		const std::vector<std::string>& getMaps() const;
 
 		/**
 		 * @brief Saves everything to be saved in the Save.
@@ -111,9 +104,13 @@ namespace phx
 		void toFile(const std::string& name = "");
 
 	private:
-		std::string              m_name;
+		std::string           m_name;
+        std::filesystem::path m_savePath;
+
 		std::vector<std::string> m_mods;
 		nlohmann::json           m_settings;
+
+        std::unordered_map<std::string, voxels::Map> m_maps;
 
 		/**
 		 * @brief Tells the saving operations whether settings have changed.
@@ -125,7 +122,5 @@ namespace phx
 		 */
 		bool m_settingsChanged = false;
 
-		// Dimension* m_defaultDimension;
-		// std::unordered_map<std::string, Dimension> m_loadedDimensions;
 	};
 } // namespace phx

--- a/Phoenix/Common/Include/Common/Voxels/Map.hpp
+++ b/Phoenix/Common/Include/Common/Voxels/Map.hpp
@@ -29,7 +29,6 @@
 #pragma once
 
 #include <Common/Math/Math.hpp>
-#include <Common/Save.hpp>
 #include <Common/Utility/BlockingQueue.hpp>
 #include <Common/Voxels/BlockReferrer.hpp>
 #include <Common/Voxels/Chunk.hpp>
@@ -70,7 +69,8 @@ namespace phx::voxels
 	class Map
 	{
 	public:
-		Map(Save* save, const std::string& name,
+		Map(std::filesystem::path* savePath,
+		    const std::string& name,
 		    voxels::BlockReferrer* referrer);
 		Map(BlockingQueue<std::pair<math::vec3, std::vector<std::byte>>>* queue,
 		    voxels::BlockReferrer* referrer);
@@ -123,8 +123,8 @@ namespace phx::voxels
 
 		BlockReferrer* m_referrer;
 
-		Save*       m_save = nullptr;
-		std::string m_mapName;
+        std::filesystem::path* m_savePath = nullptr;
+		std::string m_name;
 
 		BlockingQueue<std::pair<math::vec3, std::vector<std::byte>>>* m_queue =
 		    nullptr;


### PR DESCRIPTION
Authors:
@apachano 

## Summary of changes
- Stores map as part of save vs manually allocating memory
- Save can store more than one map

## On approval
Merge
