### PR TITLE
Dont modify safe path when opening json file

### DIFF
--- a/Phoenix/Common/Source/Save.cpp
+++ b/Phoenix/Common/Source/Save.cpp
@@ -71,7 +71,7 @@ Save::Save(const std::string& save, const std::vector<std::string>& mods,
 		LOG_INFO("SAVES") << "Loading existing save.";
 		
 		// save exists, lets load what we need.
-		std::ifstream json(m_savePath.append(save + ".json"));
+		std::ifstream json(m_savePath / (save + ".json"));
 		if (!json.is_open())
 		{
 			LOG_FATAL("SAVES")


### PR DESCRIPTION
Authors:
@apachano 

## Summary of changes
- When detecting an existing save, the json file was appended to the save path breaking future loading relying on the path. This concatenates the path in-line as a constructed argument.

## On approval
Merge
