### PR TITLE
Refactor registries to use "uid" instead of "uniqueIdentifier"

### DIFF
--- a/Phoenix/Client/Include/Client/Voxels/BlockRegistry.hpp
+++ b/Phoenix/Client/Include/Client/Voxels/BlockRegistry.hpp
@@ -196,16 +196,14 @@ namespace phx::client
 					    }
 				    }
 
-				    std::size_t blockUID   = referrer.referrer.size();
-				    block.uniqueIdentifier = blockUID;
-
-				    referrer.referrer.add(block.id, blockUID);
-				    referrer.blocks.add(blockUID, block);
+				    block.uid = referrer.referrer.size();
+				    referrer.referrer.add(block.id, block.uid);
+				    referrer.blocks.add(block.uid, block);
 
 			    	// if handles are empty, then there clearly aren't any textures so don't waste any memory :)
 			    	if (!handles.empty())
 			    	{
-					    textureHandles.add(blockUID, handles);
+					    textureHandles.add(block.uid, handles);
 			    	}
 
 			    	// only add model if a solid (entities will have different
@@ -244,7 +242,7 @@ namespace phx::client
 						    }
 					    }
 
-					    models.add(blockUID, model);
+					    models.add(block.uid, model);
 				    }
 
 				    sol::optional<std::vector<std::string>> luaSoundOnBreak =
@@ -268,7 +266,7 @@ namespace phx::client
 							        << sourceID << ")";
 						    }
 					    }
-					    SoundOnBreak.add(blockUID, onBreakSources);
+					    SoundOnBreak.add(block.uid, onBreakSources);
 				    }
 
 				    sol::optional<std::vector<std::string>> luaSoundOnPlace =
@@ -292,7 +290,7 @@ namespace phx::client
 							        << sourceID << ")";
 						    }
 					    }
-					    SoundOnPlace.add(blockUID, onPlaceSources);
+					    SoundOnPlace.add(block.uid, onPlaceSources);
 				    }
 			    });
 		}

--- a/Phoenix/Client/Include/Client/Voxels/ItemRegistry.hpp
+++ b/Phoenix/Client/Include/Client/Voxels/ItemRegistry.hpp
@@ -114,11 +114,9 @@ namespace phx::client
 					    item.onSecondary = *onSecondary;
 				    }
 
-				    std::size_t itemUID   = referrer.referrer.size();
-				    item.uniqueIdentifier = itemUID;
-
-				    referrer.referrer.add(item.id, itemUID);
-				    referrer.items.add(itemUID, item);
+				    item.uid = referrer.referrer.size();
+				    referrer.referrer.add(item.id, item.uid);
+				    referrer.items.add(item.uid, item);
 			    });
 		}
 	};

--- a/Phoenix/Client/Source/Graphics/ChunkMesher.cpp
+++ b/Phoenix/Client/Source/Graphics/ChunkMesher.cpp
@@ -56,7 +56,7 @@ std::vector<float> ChunkMesher::mesh(phx::voxels::Chunk*         chunk,
 
 		// get textures since at this point we know we're gonna be meshing
 		// something.
-		std::vector<TexturePacker::Handle>* tex = blockRegistry->textureHandles.get(block->uniqueIdentifier);
+		std::vector<TexturePacker::Handle>* tex = blockRegistry->textureHandles.get(block->uid);
 
 		auto insertToMesh = [&mesh, tex, blockRegistry,
 		                     chunkPos](DefaultMeshVertex const* vertex,
@@ -108,7 +108,7 @@ std::vector<float> ChunkMesher::mesh(phx::voxels::Chunk*         chunk,
 		// kill any modern GPU. This was written 1st Oct, 2020.
 
 		const BlockModel blockModel =
-		    *blockRegistry->models.get(block->uniqueIdentifier);
+		    *blockRegistry->models.get(block->uid);
 
 		switch (blockModel)
 		{
@@ -129,7 +129,7 @@ std::vector<float> ChunkMesher::mesh(phx::voxels::Chunk*         chunk,
 				// if the block to the north is not solid, or is not a full
 				// block, add the north face.
 				if (north->category != BlockCategory::SOLID ||
-				    *blockRegistry->models.get(north->uniqueIdentifier) !=
+				    *blockRegistry->models.get(north->uid) !=
 				        BlockModel::BLOCK)
 				{
 					insertToMesh(BLOCK_FRONT, BLOCK_FACE_VERT_COUNT,
@@ -151,7 +151,7 @@ std::vector<float> ChunkMesher::mesh(phx::voxels::Chunk*         chunk,
 				// if the block to the south is not solid, or is not a full
 				// block, add the south face.
 				if (south->category != BlockCategory::SOLID ||
-				    *blockRegistry->models.get(south->uniqueIdentifier) !=
+				    *blockRegistry->models.get(south->uid) !=
 				        BlockModel::BLOCK)
 				{
 					insertToMesh(BLOCK_BACK, BLOCK_FACE_VERT_COUNT,
@@ -172,7 +172,7 @@ std::vector<float> ChunkMesher::mesh(phx::voxels::Chunk*         chunk,
 				BlockType* bottom = blocks[Chunk::getVectorIndex(x, y - 1, z)];
 
 				if (bottom->category != BlockCategory::SOLID ||
-				    *blockRegistry->models.get(bottom->uniqueIdentifier) !=
+				    *blockRegistry->models.get(bottom->uid) !=
 				        BlockModel::BLOCK)
 				{
 					insertToMesh(BLOCK_BOTTOM, BLOCK_FACE_VERT_COUNT,
@@ -192,7 +192,7 @@ std::vector<float> ChunkMesher::mesh(phx::voxels::Chunk*         chunk,
 				BlockType* top = blocks[Chunk::getVectorIndex(x, y + 1, z)];
 
 				if (top->category != BlockCategory::SOLID ||
-				    *blockRegistry->models.get(top->uniqueIdentifier) !=
+				    *blockRegistry->models.get(top->uid) !=
 				        BlockModel::BLOCK)
 				{
 					insertToMesh(BLOCK_TOP, BLOCK_FACE_VERT_COUNT,
@@ -210,7 +210,7 @@ std::vector<float> ChunkMesher::mesh(phx::voxels::Chunk*         chunk,
 				BlockType* east = blocks[Chunk::getVectorIndex(x - 1, y, z)];
 
 				if (east->category != BlockCategory::SOLID ||
-				    *blockRegistry->models.get(east->uniqueIdentifier) !=
+				    *blockRegistry->models.get(east->uid) !=
 				        BlockModel::BLOCK)
 				{
 					insertToMesh(BLOCK_RIGHT, BLOCK_FACE_VERT_COUNT,
@@ -228,7 +228,7 @@ std::vector<float> ChunkMesher::mesh(phx::voxels::Chunk*         chunk,
 				BlockType* west = blocks[Chunk::getVectorIndex(x + 1, y, z)];
 
 				if (west->category != BlockCategory::SOLID ||
-				    *blockRegistry->models.get(west->uniqueIdentifier) !=
+				    *blockRegistry->models.get(west->uid) !=
 				        BlockModel::BLOCK)
 				{
 					insertToMesh(BLOCK_LEFT, BLOCK_FACE_VERT_COUNT,

--- a/Phoenix/Client/Source/Voxels/AudioEventHandler.cpp
+++ b/Phoenix/Client/Source/Voxels/AudioEventHandler.cpp
@@ -44,11 +44,11 @@ void AudioEventHandler::onMapEvent(const voxels::MapEvent& event)
 	{
 	case voxels::MapEvent::Event::BLOCK_BREAK:
 		play(m_blockRegistry->SoundOnBreak.get(
-		    std::get<voxels::BlockType*>(event.data)->uniqueIdentifier));
+		    std::get<voxels::BlockType*>(event.data)->uid));
 		break;
 	case voxels::MapEvent::Event::BLOCK_PLACE:
 		play(m_blockRegistry->SoundOnPlace.get(
-		    std::get<voxels::BlockType*>(event.data)->uniqueIdentifier));
+		    std::get<voxels::BlockType*>(event.data)->uid));
 		break;
 	default:
 		break;

--- a/Phoenix/Common/Include/Common/Voxels/Block.hpp
+++ b/Phoenix/Common/Include/Common/Voxels/Block.hpp
@@ -100,13 +100,14 @@ namespace phx::voxels
 
 		/// @brief The unique *identifier* for the block, this is an internal
 		/// variable.
-		std::size_t uniqueIdentifier = -1;
+		std::size_t uid = -1;
 
 		/// @brief The material state of the block.
 		BlockCategory category = BlockCategory::AIR;
 
 		/// @brief If the object can be rotated horizontally
 		bool rotH = false;
+
 		/// @brief If the block can be rotated vertically, [[rotH]] must already
 		/// be true
 		bool rotV = false;

--- a/Phoenix/Common/Include/Common/Voxels/BlockReferrer.hpp
+++ b/Phoenix/Common/Include/Common/Voxels/BlockReferrer.hpp
@@ -63,7 +63,7 @@ namespace phx::voxels
 			unknown.displayName      = "Unknown Block";
 			unknown.id               = "core.unknown";
 			unknown.category         = voxels::BlockCategory::SOLID;
-			unknown.uniqueIdentifier = uid;
+			unknown.uid              = uid;
 			referrer.add(unknown.id, uid);
 			blocks.add(uid, unknown);
 
@@ -74,7 +74,7 @@ namespace phx::voxels
 			outOfBounds.displayName      = "Out of Bounds";
 			outOfBounds.id               = "core.out_ouf_bounds";
 			outOfBounds.category         = voxels::BlockCategory::AIR;
-			outOfBounds.uniqueIdentifier = uid;
+			outOfBounds.uid              = uid;
 			referrer.add(outOfBounds.id, uid);
 			blocks.add(uid, outOfBounds);
 
@@ -84,7 +84,7 @@ namespace phx::voxels
 			air.displayName      = "Air";
 			air.id               = "core.air";
 			air.category         = voxels::BlockCategory::AIR;
-			air.uniqueIdentifier = uid;
+			air.uid              = uid;
 			referrer.add(air.id, uid);
 			blocks.add(uid, air);
 

--- a/Phoenix/Common/Include/Common/Voxels/Item.hpp
+++ b/Phoenix/Common/Include/Common/Voxels/Item.hpp
@@ -76,7 +76,7 @@ namespace phx::voxels
 
 		/// @brief The unique *identifier* for the item, this is an internal
 		/// variable.
-		std::size_t uniqueIdentifier = -1;
+		std::size_t uid = -1;
 
 		/// @brief The maximum number of items that can exist in a stack
 		std::size_t maxStack = 1;

--- a/Phoenix/Common/Include/Common/Voxels/ItemReferrer.hpp
+++ b/Phoenix/Common/Include/Common/Voxels/ItemReferrer.hpp
@@ -57,7 +57,7 @@ namespace phx::voxels
 			voxels::ItemType unknown;
 			unknown.displayName      = "Unknown Item";
 			unknown.id               = "core.unknown";
-			unknown.uniqueIdentifier = uid;
+			unknown.uid              = uid;
 			referrer.add(unknown.id, uid);
 			items.add(uid, unknown);
 
@@ -67,7 +67,7 @@ namespace phx::voxels
 			voxels::ItemType outOfBounds;
 			outOfBounds.displayName      = "Out of Bounds";
 			outOfBounds.id               = "core.out_of_bounds";
-			outOfBounds.uniqueIdentifier = uid;
+			outOfBounds.uid              = uid;
 			referrer.add(outOfBounds.id, uid);
 			items.add(uid, outOfBounds);
 

--- a/Phoenix/Common/Source/Voxels/Inventory.cpp
+++ b/Phoenix/Common/Source/Voxels/Inventory.cpp
@@ -176,7 +176,7 @@ phx::Serializer& Inventory::operator>>(phx::Serializer& ser) const
 	ser << m_size;
 	for (std::size_t i = 0; i < m_size; i++)
 	{
-		ser << m_slots[i]->uniqueIdentifier;
+		ser << m_slots[i]->uid;
 		if (m_metadata.find(i) != m_metadata.end())
 		{
 			ser << '+' << *m_metadata.at(i);

--- a/Phoenix/Common/Test/Voxels/Inventory.test.cpp
+++ b/Phoenix/Common/Test/Voxels/Inventory.test.cpp
@@ -8,10 +8,10 @@ ItemType* addTestItem(ItemReferrer& referrer)
 {
 	auto     uid = referrer.referrer.size();
 	ItemType temp;
-	temp.displayName      = &"Test"[uid];
-	temp.id               = &"core.test"[uid];
-	temp.uniqueIdentifier = uid;
-	temp.maxStack         = 64;
+	temp.displayName = &"Test"[uid];
+	temp.id          = &"core.test"[uid];
+	temp.uid         = uid;
+	temp.maxStack    = 64;
 	referrer.referrer.add(temp.id, uid);
 	referrer.items.add(uid, temp);
 	return referrer.items.get(uid);


### PR DESCRIPTION
Authors:
@apachano 

## Summary of changes
- Refactor itemType to use "uid" instead of "uniqueIdentifier" for registry index member name
- Refactor blockType to use "uid" instead of "uniqueIdentifier" for registry index member name
  
## Caveats
- There is a slight chance this confuses someone unfamiliar with the shortened word

## On approval
Merge