### PR TITLE
Refactor registries to be parents of referrers

### DIFF
--- a/Phoenix/Client/Include/Client/Voxels/BlockRegistry.hpp
+++ b/Phoenix/Client/Include/Client/Voxels/BlockRegistry.hpp
@@ -53,7 +53,7 @@ namespace phx::client
 	 * the server does not need to store things like texture paths - which is
 	 * quite essential on the client.
 	 */
-	struct BlockRegistry
+	struct BlockRegistry : public voxels::BlockReferrer
 	{
 		BlockRegistry(AudioRegistry* audioRegistry)
 		    : m_audioRegistry(audioRegistry)
@@ -71,8 +71,6 @@ namespace phx::client
 			models.setUnknownReturnVal(
 			    models.get(voxels::BlockType::UNKNOWN_BLOCK));
 		}
-
-		voxels::BlockReferrer referrer;
 
 		gfx::TexturePacker texturePacker;
 		Registry<std::size_t, std::vector<gfx::TexturePacker::Handle>>
@@ -196,9 +194,9 @@ namespace phx::client
 					    }
 				    }
 
-				    block.uid = referrer.referrer.size();
-				    referrer.referrer.add(block.id, block.uid);
-				    referrer.blocks.add(block.uid, block);
+				    block.uid = referrer.size();
+				    referrer.add(block.id, block.uid);
+				    blocks.add(block.uid, block);
 
 			    	// if handles are empty, then there clearly aren't any textures so don't waste any memory :)
 			    	if (!handles.empty())

--- a/Phoenix/Client/Include/Client/Voxels/ItemRegistry.hpp
+++ b/Phoenix/Client/Include/Client/Voxels/ItemRegistry.hpp
@@ -45,10 +45,8 @@ namespace phx::client
 	 * This holds a block referrer which handles default initialized blocks and
 	 * then provides an API registration for registering blocks from within Lua.
 	 */
-	struct ItemRegistry
+	struct ItemRegistry : public voxels::ItemReferrer
 	{
-		voxels::ItemReferrer referrer;
-
 		void registerAPI(cms::ModManager* manager)
 		{
 			manager->registerFunction(
@@ -114,10 +112,11 @@ namespace phx::client
 					    item.onSecondary = *onSecondary;
 				    }
 
-				    item.uid = referrer.referrer.size();
-				    referrer.referrer.add(item.id, item.uid);
-				    referrer.items.add(item.uid, item);
-			    });
+				    item.uid = referrer.size();
+				    referrer.add(item.id, item.uid);
+				    items.add(item.uid, item);
+			    }
+			);
 		}
 	};
 } // namespace phx::client

--- a/Phoenix/Client/Source/Game.cpp
+++ b/Phoenix/Client/Source/Game.cpp
@@ -147,15 +147,15 @@ void Game::onAttach()
 	{
         m_chat = new gfx::ChatBox(m_window, &m_network->messageQueue);
 		m_map =
-		    new voxels::Map(&m_network->chunkQueue, &m_blockRegistry.referrer);
+		    new voxels::Map(&m_network->chunkQueue, &m_blockRegistry);
 	}
 	else
 	{
         m_chat = new gfx::ChatBox(m_window, nullptr);
-		m_map = m_save->getOrCreateMap("Map1", &m_blockRegistry.referrer);
+		m_map = m_save->getOrCreateMap("Map1", &m_blockRegistry);
 	}
 	m_invManager =
-	    new voxels::InventoryManager(m_save, &m_itemRegistry.referrer);
+	    new voxels::InventoryManager(m_save, &m_itemRegistry);
 	m_playerInventory =
 	    m_invManager->getInventory(m_invManager->createInventory(30));
 
@@ -178,7 +178,7 @@ void Game::onAttach()
 	LOG_INFO("MAIN") << "Register GUI";
 	m_escapeMenu = new EscapeMenu(m_window, m_camera);
 	m_inventory  = new InventoryUI(m_window, m_camera, m_playerInventory,
-                                  &m_itemRegistry.referrer);
+                                  &m_itemRegistry);
 
 	if (Client::get()->isDebugLayerActive())
 	{
@@ -282,13 +282,13 @@ void Game::onEvent(events::Event& e)
 		switch (e.mouse.button)
 		{
 		case events::MouseButtons::LEFT:
-			ActorSystem::action1(&m_blockRegistry.referrer, m_registry,
+			ActorSystem::action1(&m_blockRegistry, m_registry,
 			                     m_player);
 			e.handled = true;
 			break;
 
 		case events::MouseButtons::RIGHT:
-			ActorSystem::action2(&m_blockRegistry.referrer, m_registry,
+			ActorSystem::action2(&m_blockRegistry, m_registry,
 			                     m_player);
 			e.handled = true;
 			break;


### PR DESCRIPTION
Authors:
@apachano 

## Summary of changes
- Refactor ItemReferrer to be a parent of the ItemRegistry instead of a member
- Refactor blockReferrer to be a parent of the blockRegistry instead of a member

## On approval
Merge
