### PR TITLE
Fix CI with GLSLC support.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,7 @@ jobs:
         if: matrix.config.os == 'windows-latest'
         
       - name: Setup Vulkan (Ubuntu)
-        run: sudo apt-get install libvulkan
+        run: sudo apt-get install spirv-tools
         if: matrix.config.os == 'ubuntu-20.04'
 
       - name: Configure CMake

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,7 @@ jobs:
     env:
       CC: ${{ matrix.config.cc }}
       CXX: ${{ matrix.config.cxx }}
+      VULKAN_SDK: ${{ github.workspace }}\VulkanSDK
 
     steps:
       - uses: actions/checkout@v2
@@ -33,18 +34,22 @@ jobs:
         uses: egor-tensin/vs-shell@v2
 
       - name: Setup Vulkan (Windows)
-        run: |
-          $ver = (Invoke-WebRequest -Uri "https://vulkan.lunarg.com/sdk/latest.json" | ConvertFrom-Json).windows
-          echo Version $ver
-          $ProgressPreference = 'SilentlyContinue'
-          Invoke-WebRequest -Uri "https://sdk.lunarg.com/sdk/download/$ver/windows/VulkanSDK-$ver-Installer.exe" -OutFile VulkanSDK.exe
-          echo Downloaded
-          .\VulkanSDK.exe --root C:\VulkanSDK  --accept-licenses --default-answer --confirm-command install
         if: matrix.config.os == 'windows-latest'
+        uses: actions/checkout@v2
+        with:
+          repository: beeperdeeper089/VulkanContinuousIntegrationTools
+          path: ${{ env.VULKAN_SDK }}
+          ref: Windows
         
       - name: Setup Vulkan (Ubuntu)
-        run: sudo apt-get install glslang-tools
         if: matrix.config.os == 'ubuntu-20.04'
+        uses: actions/checkout@v2
+        with:
+          repository: beeperdeeper089/VulkanContinuousIntegrationTools
+          path: ${{ env.VULKAN_SDK }}
+          ref: Linux
+       
+      - run: echo "${{ env.VULKAN_SDK }}/Bin" >> $GITHUB_PATH
 
       - name: Configure CMake
         run: cmake -S. -BBuild -GNinja -DCMAKE_BUILD_TYPE=${{ matrix.config.build_type }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,6 +32,12 @@ jobs:
       - name: Set up Visual Studio shell
         uses: egor-tensin/vs-shell@v2
 
+      - name: Install Vulkan SDK
+        uses: humbletim/install-vulkan-sdk@v1.1.1
+        with:
+          version: 1.3.204.0
+          cache: true
+
       - name: Configure CMake
         run: cmake -S. -BBuild -GNinja -DCMAKE_BUILD_TYPE=${{ matrix.config.build_type }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
     env:
       CC: ${{ matrix.config.cc }}
       CXX: ${{ matrix.config.cxx }}
-      VULKAN_SDK: ${{ github.workspace }}\VulkanSDK
+      VULKAN_SDK: ${{ github.workspace }}/VulkanSDK
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Visual Studio shell
         uses: egor-tensin/vs-shell@v2
 
-      - name: Setup Vulkan
+      - name: Setup Vulkan (Windows)
         run: |
           $ver = (Invoke-WebRequest -Uri "https://vulkan.lunarg.com/sdk/latest.json" | ConvertFrom-Json).windows
           echo Version $ver
@@ -42,7 +42,7 @@ jobs:
           .\VulkanSDK.exe --root C:\VulkanSDK  --accept-licenses --default-answer --confirm-command install
         if: matrix.os == 'windows-latest'
         
-      - name: Setup Vulkan
+      - name: Setup Vulkan (Ubuntu)
         run: sudo apt-get install libvulkan
         if: matrix.os == 'ubuntu-20.04'
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,10 +33,11 @@ jobs:
         uses: egor-tensin/vs-shell@v2
 
       - name: Install Vulkan SDK
-        uses: humbletim/install-vulkan-sdk@v1.1.1
+        uses: humbletim/setup-vulkan-sdk@v1.2.0
         with:
-          version: 1.3.204.0
-          cache: true
+          vulkan-query-version: 1.3.204.0
+          vulkan-components: Glslang
+          vulkan-use-cache: true
 
       - name: Configure CMake
         run: cmake -S. -BBuild -GNinja -DCMAKE_BUILD_TYPE=${{ matrix.config.build_type }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,11 +40,11 @@ jobs:
           Invoke-WebRequest -Uri "https://sdk.lunarg.com/sdk/download/$ver/windows/VulkanSDK-$ver-Installer.exe" -OutFile VulkanSDK.exe
           echo Downloaded
           .\VulkanSDK.exe --root C:\VulkanSDK  --accept-licenses --default-answer --confirm-command install
-        if: matrix.os == 'windows-latest'
+        if: matrix.config.os == 'windows-latest'
         
       - name: Setup Vulkan (Ubuntu)
         run: sudo apt-get install libvulkan
-        if: matrix.os == 'ubuntu-20.04'
+        if: matrix.config.os == 'ubuntu-20.04'
 
       - name: Configure CMake
         run: cmake -S. -BBuild -GNinja -DCMAKE_BUILD_TYPE=${{ matrix.config.build_type }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,7 @@ jobs:
         if: matrix.config.os == 'windows-latest'
         
       - name: Setup Vulkan (Ubuntu)
-        run: sudo apt-get install spirv-tools
+        run: sudo apt-get install glslang-tools
         if: matrix.config.os == 'ubuntu-20.04'
 
       - name: Configure CMake

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,12 +32,19 @@ jobs:
       - name: Set up Visual Studio shell
         uses: egor-tensin/vs-shell@v2
 
-      - name: Install Vulkan SDK
-        uses: humbletim/setup-vulkan-sdk@v1.2.0
-        with:
-          vulkan-query-version: 1.3.204.0
-          vulkan-components: Glslang
-          vulkan-use-cache: true
+      - name: Setup Vulkan
+        run: |
+          $ver = (Invoke-WebRequest -Uri "https://vulkan.lunarg.com/sdk/latest.json" | ConvertFrom-Json).windows
+          echo Version $ver
+          $ProgressPreference = 'SilentlyContinue'
+          Invoke-WebRequest -Uri "https://sdk.lunarg.com/sdk/download/$ver/windows/VulkanSDK-$ver-Installer.exe" -OutFile VulkanSDK.exe
+          echo Downloaded
+          .\VulkanSDK.exe --root C:\VulkanSDK  --accept-licenses --default-answer --confirm-command install
+        if: matrix.os == 'windows-latest'
+        
+      - name: Setup Vulkan
+        run: sudo apt-get install libvulkan
+        if: matrix.os == 'ubuntu-20.04'
 
       - name: Configure CMake
         run: cmake -S. -BBuild -GNinja -DCMAKE_BUILD_TYPE=${{ matrix.config.build_type }}

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ Makefile
 *.a
 *.lib
 *.exe
+
+# Compiled shaders
+*.spv

--- a/latest/CMakeLists.txt
+++ b/latest/CMakeLists.txt
@@ -6,9 +6,6 @@ set(ShaderDir ${CMAKE_CURRENT_LIST_DIR}/data/Shaders)
 file(GLOB_RECURSE Shaders ${ShaderDir}/*.*)
 file(GLOB_RECURSE ShadersToCompile ${ShaderDir}/*.vert ${ShaderDir}/*.frag ${ShaderDir}/*.comp)
 
-# GLSLC will compile our GLSL shaders to SPIR-V.
-find_program(GLSLC glslc)
-
 # This will compile shader.frag -> frag.spv, shader.vert -> vert.spv, etc...
 
 foreach(ShaderFile ${ShadersToCompile})
@@ -22,7 +19,7 @@ foreach(ShaderFile ${ShadersToCompile})
 
 	add_custom_command(
 		OUTPUT ${CurrentOutputPath}
-		COMMAND ${GLSLC} -o ${CurrentOutputPath} ${ShaderFile}
+		COMMAND glslc -o ${CurrentOutputPath} ${ShaderFile}
 		DEPENDS ${ShaderFile}
 		IMPLICIT_DEPENDS CXX ${ShaderFile}
 		VERBATIM

--- a/latest/CMakeLists.txt
+++ b/latest/CMakeLists.txt
@@ -22,7 +22,7 @@ if (NOT DEFINED {VULKAN_SDK})
 endif()
 
 message("Vulkan SDK path: " ${VULKAN_SDK})
-set(GLSL_COMPILER ${VULKAN_SDK}/bin/glslc)
+set(GLSL_COMPILER ${VULKAN_SDK}/Bin/glslc)
 
 # This will compile shader.frag -> frag.spv, shader.vert -> vert.spv, etc...
 

--- a/latest/CMakeLists.txt
+++ b/latest/CMakeLists.txt
@@ -6,6 +6,24 @@ set(ShaderDir ${CMAKE_CURRENT_LIST_DIR}/data/Shaders)
 file(GLOB_RECURSE Shaders ${ShaderDir}/*.*)
 file(GLOB_RECURSE ShadersToCompile ${ShaderDir}/*.vert ${ShaderDir}/*.frag ${ShaderDir}/*.comp)
 
+# Find Vulkan SDK
+# From: https://github.com/krOoze/Hello_Triangle/ & their vk_sdk_lite repo.
+if (NOT DEFINED {VULKAN_SDK})
+	if (NOT DEFINED ENV{VULKAN_SDK})
+		message(FATAL_ERROR "VULKAN_SDK not found!")
+	endif()
+
+	if (CYGWIN)
+		execute_process(COMMAND cygpath "$ENV{VULKAN_SDK}" OUTPUT_VARIABLE VULKAN_SDK)
+		string(STRIP ${VULKAN_SDK} VULKAN_SDK)
+	else()
+		set(VULKAN_SDK "$ENV{VULKAN_SDK}")
+	endif()
+endif()
+
+message("Vulkan SDK path: " ${VULKAN_SDK})
+set(GLSL_COMPILER ${VULKAN_SDK}/bin/glslc)
+
 # This will compile shader.frag -> frag.spv, shader.vert -> vert.spv, etc...
 
 foreach(ShaderFile ${ShadersToCompile})
@@ -19,7 +37,7 @@ foreach(ShaderFile ${ShadersToCompile})
 
 	add_custom_command(
 		OUTPUT ${CurrentOutputPath}
-		COMMAND glslc -o ${CurrentOutputPath} ${ShaderFile}
+		COMMAND ${GLSL_COMPILER} -o ${CurrentOutputPath} ${ShaderFile}
 		DEPENDS ${ShaderFile}
 		IMPLICIT_DEPENDS CXX ${ShaderFile}
 		VERBATIM

--- a/latest/CMakeLists.txt
+++ b/latest/CMakeLists.txt
@@ -22,7 +22,7 @@ foreach(ShaderFile ${ShadersToCompile})
 
 	add_custom_command(
 		OUTPUT ${CurrentOutputPath}
-		COMMAND glslc -o ${CurrentOutputPath} ${ShaderFile}
+		COMMAND ${GLSLC} -o ${CurrentOutputPath} ${ShaderFile}
 		DEPENDS ${ShaderFile}
 		IMPLICIT_DEPENDS CXX ${ShaderFile}
 		VERBATIM

--- a/latest/CMakeLists.txt
+++ b/latest/CMakeLists.txt
@@ -6,6 +6,9 @@ set(ShaderDir ${CMAKE_CURRENT_LIST_DIR}/data/Shaders)
 file(GLOB_RECURSE Shaders ${ShaderDir}/*.*)
 file(GLOB_RECURSE ShadersToCompile ${ShaderDir}/*.vert ${ShaderDir}/*.frag ${ShaderDir}/*.comp)
 
+# GLSLC will compile our GLSL shaders to SPIR-V.
+find_program(GLSLC glslc)
+
 # This will compile shader.frag -> frag.spv, shader.vert -> vert.spv, etc...
 
 foreach(ShaderFile ${ShadersToCompile})


### PR DESCRIPTION
Since CMake now compiles the GLSL shaders, we need to give it a way to actually find GLSLC without downloading a massive VulkanSDK.

A secondary repository has been made at [beeperdeeper089/VulkanContinuousIntegrationTools](https://github.com/beeperdeeper089/VulkanContinuousIntegrationTools) to facilitate this.